### PR TITLE
Add away state and chat polish

### DIFF
--- a/src/components/LiveChat.scss
+++ b/src/components/LiveChat.scss
@@ -33,6 +33,20 @@
   }
 }
 
+@keyframes away-z-drift {
+  0% {
+    transform: translate(1px, -5px);
+    opacity: 0;
+  }
+  35% {
+    opacity: 0.8;
+  }
+  100% {
+    transform: translate(2px, -12px);
+    opacity: 0;
+  }
+}
+
 .live-chat {
   position: fixed;
   bottom: 0rem;
@@ -228,10 +242,18 @@
   }
 }
 
+.live-chat-spencer-dot {
+  position: relative;
+}
+
 .live-chat-away-mark {
+  animation: away-z-drift 1.4s steps(3, end) infinite;
+  color: #777;
   font-size: 9px;
   line-height: 1;
-  opacity: 0.6;
+  position: absolute;
+  right: -2px;
+  top: -2px;
 }
 
 .live-chat-name {

--- a/src/components/LiveChat.scss
+++ b/src/components/LiveChat.scss
@@ -39,7 +39,7 @@
     opacity: 0;
   }
   35% {
-    opacity: 0.8;
+    opacity: 1;
   }
   100% {
     transform: translate(2px, -12px);
@@ -248,12 +248,23 @@
 
 .live-chat-away-mark {
   animation: away-z-drift 1.4s steps(3, end) infinite;
-  color: #777;
+  color: #1a1a1a;
   font-size: 9px;
+  font-weight: 700;
   line-height: 1;
   position: absolute;
   right: -2px;
+  text-shadow:
+    0 0 2px #fff,
+    0 0 2px #fff;
   top: -2px;
+
+  .dark-mode & {
+    color: #fff;
+    text-shadow:
+      0 0 2px #000,
+      0 0 2px #000;
+  }
 }
 
 .live-chat-name {

--- a/src/components/LiveChat.scss
+++ b/src/components/LiveChat.scss
@@ -149,7 +149,7 @@
   border-bottom: 1px dotted currentColor;
   background: transparent;
   padding: 0 1px;
-  width: 7em;
+  width: 5em;
 
   &:focus {
     outline: none;
@@ -202,6 +202,24 @@
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
+}
+
+.live-chat-spencer-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  white-space: nowrap;
+
+  &.away .live-chat-spencer-dot {
+    opacity: 0.4;
+    filter: grayscale(0.2);
+  }
+}
+
+.live-chat-away-mark {
+  font-size: 9px;
+  line-height: 1;
+  opacity: 0.6;
 }
 
 .live-chat-name {

--- a/src/components/LiveChat.scss
+++ b/src/components/LiveChat.scss
@@ -37,7 +37,7 @@
   position: fixed;
   bottom: 0rem;
   right: 0.25rem;
-  width: 320px;
+  width: 360px;
   z-index: 9998;
   font-family: var(--site-font-mono, "Sono", "Courier New", monospace);
   font-size: 13px;

--- a/src/components/LiveChat.scss
+++ b/src/components/LiveChat.scss
@@ -173,16 +173,26 @@
 }
 
 .live-chat-message {
-  display: flex;
-  gap: 5px;
-  align-items: baseline;
+  display: block;
 
   .live-chat-text {
     min-width: 0;
     overflow-wrap: anywhere;
   }
 
+  &.replyable {
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 1px dotted currentColor;
+      outline-offset: 2px;
+    }
+  }
+
   &.system {
+    display: flex;
+    gap: 5px;
+    align-items: baseline;
     font-size: 11px;
     opacity: 0.5;
     text-align: center;
@@ -190,10 +200,21 @@
   }
 
   &.typing {
+    display: flex;
+    gap: 5px;
+    align-items: baseline;
     opacity: 0.5;
     font-style: italic;
     font-size: 11px;
   }
+}
+
+.live-chat-message-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-right: 5px;
+  vertical-align: baseline;
 }
 
 .live-chat-dot {

--- a/src/components/LiveChat.scss
+++ b/src/components/LiveChat.scss
@@ -180,15 +180,6 @@
     overflow-wrap: anywhere;
   }
 
-  &.replyable {
-    cursor: pointer;
-
-    &:focus-visible {
-      outline: 1px dotted currentColor;
-      outline-offset: 2px;
-    }
-  }
-
   &.system {
     display: flex;
     gap: 5px;

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -11,7 +11,12 @@ import React, {
 } from "react";
 import { PlayContext, playhtml, useCursorPresences, usePresenceRoom } from "@playhtml/react";
 import { useStore } from "@nanostores/react";
-import { isSpencer, SPENCER_COLOR, getSpencerStableId } from "../utils/presence";
+import {
+  isSpencer,
+  SPENCER_COLOR,
+  getSpencerStableId,
+  getSpencerChatStatus,
+} from "../utils/presence";
 import {
   $chatMessages,
   $chatVisible,
@@ -60,6 +65,9 @@ export function LiveChat() {
   const [myColor, setMyColor] = useState(() => window.cursors?.color ?? "#888");
   const [flashTitlebar, setFlashTitlebar] = useState(false);
   const [typingStableIds, setTypingStableIds] = useState<Set<string>>(new Set());
+  const [activePresences, setActivePresences] = useState<
+    Map<string, { active?: boolean }>
+  >(new Map());
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -85,6 +93,10 @@ export function LiveChat() {
     () => getSpencerStableId(cursorPresences),
     [cursorPresences],
   );
+  const spencerChatStatus = useMemo(
+    () => getSpencerChatStatus(cursorPresences, activePresences),
+    [cursorPresences, activePresences],
+  );
 
   // Keep the displayed name and color in sync with updates from elsewhere (Stats, Guestbook)
   useEffect(() => {
@@ -108,15 +120,27 @@ export function LiveChat() {
     }
   }, []);
 
+  useEffect(() => {
+    if (!hasSynced) return;
+    const unsub = playhtml.presence.onPresenceChange("active", (presences) => {
+      const next = new Map<string, { active?: boolean }>();
+      for (const [stableId, view] of presences) {
+        next.set(stableId, { active: (view as any).active });
+      }
+      setActivePresences(next);
+    });
+    return unsub;
+  }, [hasSynced]);
+
   // Show chat when Spencer arrives
   useEffect(() => {
     if (!hasSynced) return;
     if (dismissed) return;
-    if (spencerStableId && !visible) {
+    if (spencerChatStatus !== "absent" && !visible) {
       $chatVisible.set(true);
       $chatSpencerLeft.set(false);
       $chatMessages.set([
-        ...messages,
+        ...$chatMessages.get(),
         {
           id: `system-${Date.now()}`,
           text: "spencer just arrived",
@@ -126,10 +150,10 @@ export function LiveChat() {
           type: "system",
         },
       ]);
-    } else if (!spencerStableId && visible && !spencerLeft) {
+    } else if (spencerChatStatus === "absent" && visible && !spencerLeft) {
       $chatSpencerLeft.set(true);
       $chatMessages.set([
-        ...messages,
+        ...$chatMessages.get(),
         {
           id: `system-${Date.now()}`,
           text: "spencer has left",
@@ -140,7 +164,7 @@ export function LiveChat() {
         },
       ]);
     }
-  }, [spencerStableId, hasSynced, visible, spencerLeft, dismissed]);
+  }, [spencerChatStatus, hasSynced, visible, spencerLeft, dismissed]);
 
   // HACK: Using presence channel for messaging because play events are page-scoped,
   // not domain-scoped. Each user's latest message is set as their "chat-msg" presence,
@@ -436,19 +460,28 @@ export function LiveChat() {
           </span>
           {" · "}
           {pplCount} ppl here
-          {spencerStableId && (
+          {spencerChatStatus !== "absent" && (
             <>
               {" "}·{" "}
               <span
-                className="live-chat-dot"
-                style={{
-                  width: "6px",
-                  height: "6px",
-                  backgroundColor: SPENCER_COLOR,
-                  boxShadow: `0 0 3px ${SPENCER_COLOR}`,
-                }}
-              />{" "}
-              spencer is home
+                className={`live-chat-spencer-status ${
+                  spencerChatStatus === "away" ? "away" : ""
+                }`}
+              >
+                <span
+                  className="live-chat-dot live-chat-spencer-dot"
+                  style={{
+                    width: "6px",
+                    height: "6px",
+                    backgroundColor: SPENCER_COLOR,
+                    boxShadow: `0 0 3px ${SPENCER_COLOR}`,
+                  }}
+                />
+                {spencerChatStatus === "away" && (
+                  <span className="live-chat-away-mark">Z z z</span>
+                )}
+                spencer is {spencerChatStatus}
+              </span>
             </>
           )}
         </div>

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -24,9 +24,8 @@ import {
   $chatSpencerLeft,
   $chatUnreadCount,
   $chatDismissed,
-  type ChatMessage,
 } from "../stores/chat";
-import { isScrolledNearBottom, startReplyDraft } from "../utils/chat";
+import { isScrolledNearBottom } from "../utils/chat";
 import "./LiveChat.scss";
 
 const URL_PATTERN = /(https?:\/\/[^\s<>"']+[^\s<>"'.,!?)\]}])/g;
@@ -42,7 +41,6 @@ function renderMessageText(text: string): React.ReactNode {
           href={part}
           target="_blank"
           rel="noopener noreferrer nofollow"
-          onClick={(e) => e.stopPropagation()}
         >
           {part}
         </a>
@@ -73,7 +71,6 @@ export function LiveChat() {
   const messagesRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
   const shouldAutoScrollRef = useRef(true);
   const minimizedRef = useRef(false);
   minimizedRef.current = minimized;
@@ -390,13 +387,6 @@ export function LiveChat() {
     [sendMessage],
   );
 
-  const handleReplyToMessage = useCallback((msg: ChatMessage) => {
-    setInputValue((current) => startReplyDraft(current, msg.name));
-    window.requestAnimationFrame(() => {
-      inputRef.current?.focus();
-    });
-  }, []);
-
   const handleExpand = useCallback(() => {
     $chatMinimized.set(false);
     $chatUnreadCount.set(0);
@@ -533,17 +523,7 @@ export function LiveChat() {
             return (
               <div
                 key={msg.id}
-                className="live-chat-message replyable"
-                role="button"
-                tabIndex={0}
-                title={`reply to ${msg.name ?? "someone"}`}
-                onClick={() => handleReplyToMessage(msg)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    handleReplyToMessage(msg);
-                  }
-                }}
+                className="live-chat-message"
               >
                 <span className="live-chat-message-meta">
                   <span
@@ -585,7 +565,6 @@ export function LiveChat() {
         </div>
         <div className="live-chat-input">
           <input
-            ref={inputRef}
             value={inputValue}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -26,6 +26,7 @@ import {
   $chatDismissed,
   type ChatMessage,
 } from "../stores/chat";
+import { startReplyDraft } from "../utils/chat";
 import "./LiveChat.scss";
 
 const URL_PATTERN = /(https?:\/\/[^\s<>"']+[^\s<>"'.,!?)\]}])/g;
@@ -41,6 +42,7 @@ function renderMessageText(text: string): React.ReactNode {
           href={part}
           target="_blank"
           rel="noopener noreferrer nofollow"
+          onClick={(e) => e.stopPropagation()}
         >
           {part}
         </a>
@@ -374,6 +376,13 @@ export function LiveChat() {
     [sendMessage],
   );
 
+  const handleReplyToMessage = useCallback((msg: ChatMessage) => {
+    setInputValue((current) => startReplyDraft(current, msg.name));
+    window.requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+  }, []);
+
   const handleExpand = useCallback(() => {
     $chatMinimized.set(false);
     $chatUnreadCount.set(0);
@@ -504,15 +513,21 @@ export function LiveChat() {
             const msgIsSpencer =
               msg.name === "spencer" && msg.color === SPENCER_COLOR;
             return (
-              <div key={msg.id} className="live-chat-message">
-                <span
-                  style={{
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: "3px",
-                    flexShrink: 0,
-                  }}
-                >
+              <div
+                key={msg.id}
+                className="live-chat-message replyable"
+                role="button"
+                tabIndex={0}
+                title={`reply to ${msg.name ?? "someone"}`}
+                onClick={() => handleReplyToMessage(msg)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleReplyToMessage(msg);
+                  }
+                }}
+              >
+                <span className="live-chat-message-meta">
                   <span
                     className="live-chat-dot"
                     style={{

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -489,10 +489,11 @@ export function LiveChat() {
                     backgroundColor: SPENCER_COLOR,
                     boxShadow: `0 0 3px ${SPENCER_COLOR}`,
                   }}
-                />
-                {spencerChatStatus === "away" && (
-                  <span className="live-chat-away-mark">Z z z</span>
-                )}
+                >
+                  {spencerChatStatus === "away" && (
+                    <span className="live-chat-away-mark">z</span>
+                  )}
+                </span>
                 {spencerChatStatus === "away" ? "spencer is away" : "spencer home"}
               </span>
             </>

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -480,7 +480,7 @@ export function LiveChat() {
                 {spencerChatStatus === "away" && (
                   <span className="live-chat-away-mark">Z z z</span>
                 )}
-                spencer is {spencerChatStatus}
+                {spencerChatStatus === "away" ? "spencer is away" : "spencer home"}
               </span>
             </>
           )}

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -477,7 +477,7 @@ export function LiveChat() {
               type="text"
               value={name}
               onChange={(e) => handleNameChange(e.target.value)}
-              placeholder="set a name..."
+              placeholder="name"
               maxLength={20}
             />
           </span>

--- a/src/components/LiveChat.tsx
+++ b/src/components/LiveChat.tsx
@@ -26,7 +26,7 @@ import {
   $chatDismissed,
   type ChatMessage,
 } from "../stores/chat";
-import { startReplyDraft } from "../utils/chat";
+import { isScrolledNearBottom, startReplyDraft } from "../utils/chat";
 import "./LiveChat.scss";
 
 const URL_PATTERN = /(https?:\/\/[^\s<>"']+[^\s<>"'.,!?)\]}])/g;
@@ -70,9 +70,11 @@ export function LiveChat() {
   const [activePresences, setActivePresences] = useState<
     Map<string, { active?: boolean }>
   >(new Map());
+  const messagesRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const shouldAutoScrollRef = useRef(true);
   const minimizedRef = useRef(false);
   minimizedRef.current = minimized;
   // Stable IDs (→ {name, color}) of people who have sent a chat message this
@@ -328,10 +330,21 @@ export function LiveChat() {
     return unsub;
   }, [room]);
 
-  // Auto-scroll to bottom on new messages
+  // Keep the chat pinned only while the user is already reading the latest messages.
   useEffect(() => {
+    if (!shouldAutoScrollRef.current) return;
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, typingStableIds]);
+
+  const handleMessagesScroll = useCallback(() => {
+    const messagesEl = messagesRef.current;
+    if (!messagesEl) return;
+    shouldAutoScrollRef.current = isScrolledNearBottom(
+      messagesEl.scrollTop,
+      messagesEl.clientHeight,
+      messagesEl.scrollHeight,
+    );
+  }, []);
 
   const sendMessage = useCallback(() => {
     const text = inputValue.trim();
@@ -346,6 +359,7 @@ export function LiveChat() {
     // Broadcast via presence room — the listener will pick it up and dedup
     room.presence.setMyPresence("chat-msg", { text, stableId, color, name, timestamp });
 
+    shouldAutoScrollRef.current = true;
     setInputValue("");
     room.presence.setMyPresence("typing", null);
   }, [inputValue, room]);
@@ -494,7 +508,11 @@ export function LiveChat() {
             </>
           )}
         </div>
-        <div className="live-chat-messages">
+        <div
+          ref={messagesRef}
+          className="live-chat-messages"
+          onScroll={handleMessagesScroll}
+        >
           {messages.map((msg) => {
             if (msg.type === "system") {
               return (

--- a/src/components/interactive/PlayhtmlProvider.tsx
+++ b/src/components/interactive/PlayhtmlProvider.tsx
@@ -151,6 +151,7 @@ export function PlayhtmlProvider({ children }: PropsWithChildren) {
         cursors: {
           enabled: true,
           room: "domain",
+          coordinateMode: "absolute",
           container: "#playhtml-cursor-container",
           getCursorStyle: (presence) => {
             if (presence.page !== window.location.pathname) {

--- a/src/components/interactive/PlayhtmlProvider.tsx
+++ b/src/components/interactive/PlayhtmlProvider.tsx
@@ -6,6 +6,13 @@ import { useContext, useEffect, type PropsWithChildren } from "react";
 import { CursorPresenceLayer } from "./CursorPresenceLayer";
 import { LiveChat } from "../LiveChat";
 import { isRegular } from "../../utils/roles";
+import {
+  VISITOR_AWAY_DELAY_MS,
+  getVisitorAvailability,
+} from "../../utils/presence";
+
+const VISIBLE_TAB_HEARTBEAT_KEY = "spencer-place-visible-tab-at";
+const VISIBLE_TAB_HEARTBEAT_INTERVAL_MS = 5_000;
 
 // Migrate legacy "username" from localStorage into playhtml's identity if needed.
 // Runs once before PlayProvider initializes the cursor client.
@@ -40,23 +47,85 @@ function PresenceBroadcaster() {
   useEffect(() => {
     if (!hasSynced) return;
 
+    let hiddenSince = document.hidden ? Date.now() : null;
+    let awayTimer: ReturnType<typeof setTimeout> | null = null;
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+    const getLastVisibleAt = () => {
+      const value = localStorage.getItem(VISIBLE_TAB_HEARTBEAT_KEY);
+      if (!value) return null;
+      const timestamp = Number(value);
+      return Number.isFinite(timestamp) ? timestamp : null;
+    };
+
+    const writeVisibleHeartbeat = () => {
+      localStorage.setItem(VISIBLE_TAB_HEARTBEAT_KEY, String(Date.now()));
+    };
+
+    const broadcastAvailability = () => {
+      const availability = getVisitorAvailability(
+        document.hidden,
+        hiddenSince,
+        getLastVisibleAt(),
+      );
+      playhtml.presence.setMyPresence("active", availability === "available");
+    };
+
+    const clearAwayTimer = () => {
+      if (awayTimer) {
+        clearTimeout(awayTimer);
+        awayTimer = null;
+      }
+    };
+
+    const scheduleAwayTimer = () => {
+      clearAwayTimer();
+      awayTimer = setTimeout(() => {
+        broadcastAvailability();
+      }, VISITOR_AWAY_DELAY_MS);
+    };
+
     // Broadcast current page, active state, and regular status
     playhtml.presence.setMyPresence("page", window.location.pathname);
     playhtml.presence.setMyPresence("regular", isRegular());
-    playhtml.presence.setMyPresence("active", !document.hidden);
+    if (!document.hidden) {
+      writeVisibleHeartbeat();
+    } else {
+      scheduleAwayTimer();
+    }
+    broadcastAvailability();
 
     const handleVisibility = () => {
-      playhtml.presence.setMyPresence("active", !document.hidden);
+      if (document.hidden) {
+        hiddenSince = Date.now();
+        broadcastAvailability();
+        scheduleAwayTimer();
+      } else {
+        hiddenSince = null;
+        clearAwayTimer();
+        writeVisibleHeartbeat();
+        broadcastAvailability();
+      }
     };
     // Update page on view transition navigation
     const handlePageLoad = () => {
       playhtml.presence.setMyPresence("page", window.location.pathname);
     };
 
+    heartbeatTimer = setInterval(() => {
+      if (!document.hidden) {
+        writeVisibleHeartbeat();
+        broadcastAvailability();
+      }
+    }, VISIBLE_TAB_HEARTBEAT_INTERVAL_MS);
     document.addEventListener("visibilitychange", handleVisibility);
     document.addEventListener("astro:page-load", handlePageLoad);
 
     return () => {
+      clearAwayTimer();
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+      }
       document.removeEventListener("visibilitychange", handleVisibility);
       document.removeEventListener("astro:page-load", handlePageLoad);
     };

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -1,17 +1,5 @@
-// ABOUTME: Shared text helpers for the live chat component.
-// ABOUTME: Keeps chat input draft behavior testable outside React.
-
-function mentionName(name?: string): string {
-  const trimmed = name?.trim();
-  return trimmed ? trimmed.replace(/\s+/g, "-") : "someone";
-}
-
-export function startReplyDraft(currentDraft: string, name?: string): string {
-  const mention = `@${mentionName(name)}`;
-  const trimmedDraft = currentDraft.trimStart();
-  if (trimmedDraft.startsWith(`${mention} `)) return currentDraft;
-  return trimmedDraft ? `${mention} ${trimmedDraft}` : `${mention} `;
-}
+// ABOUTME: Shared behavior helpers for the live chat component.
+// ABOUTME: Keeps chat scroll decisions testable outside React.
 
 export function isScrolledNearBottom(
   scrollTop: number,

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -12,3 +12,12 @@ export function startReplyDraft(currentDraft: string, name?: string): string {
   if (trimmedDraft.startsWith(`${mention} `)) return currentDraft;
   return trimmedDraft ? `${mention} ${trimmedDraft}` : `${mention} `;
 }
+
+export function isScrolledNearBottom(
+  scrollTop: number,
+  clientHeight: number,
+  scrollHeight: number,
+  threshold = 24,
+): boolean {
+  return scrollHeight - scrollTop - clientHeight <= threshold;
+}

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -1,0 +1,14 @@
+// ABOUTME: Shared text helpers for the live chat component.
+// ABOUTME: Keeps chat input draft behavior testable outside React.
+
+function mentionName(name?: string): string {
+  const trimmed = name?.trim();
+  return trimmed ? trimmed.replace(/\s+/g, "-") : "someone";
+}
+
+export function startReplyDraft(currentDraft: string, name?: string): string {
+  const mention = `@${mentionName(name)}`;
+  const trimmedDraft = currentDraft.trimStart();
+  if (trimmedDraft.startsWith(`${mention} `)) return currentDraft;
+  return trimmedDraft ? `${mention} ${trimmedDraft}` : `${mention} `;
+}

--- a/src/utils/presence.ts
+++ b/src/utils/presence.ts
@@ -4,6 +4,10 @@
 import type { CursorPresenceView } from "@playhtml/common";
 
 export const SPENCER_COLOR = "hsl(41, 100%, 50%)";
+export const VISITOR_AWAY_DELAY_MS = 30_000;
+
+export type SpencerChatStatus = "absent" | "home" | "away";
+export type VisitorAvailability = "available" | "away";
 
 let normalizedSpencerColor: string | null = null;
 
@@ -37,4 +41,29 @@ export function getSpencerStableId(
     if (isSpencer(presence)) return stableId;
   }
   return null;
+}
+
+export function getSpencerChatStatus(
+  presences: Map<string, CursorPresenceView>,
+  activePresences: Map<string, { active?: boolean }>,
+): SpencerChatStatus {
+  const stableId = getSpencerStableId(presences);
+  if (!stableId) return "absent";
+
+  return activePresences.get(stableId)?.active === false ? "away" : "home";
+}
+
+export function getVisitorAvailability(
+  isHidden: boolean,
+  hiddenSince: number | null,
+  lastVisibleAt: number | null,
+  now = Date.now(),
+): VisitorAvailability {
+  if (!isHidden) return "available";
+  if (hiddenSince === null) return "available";
+  if (now - hiddenSince < VISITOR_AWAY_DELAY_MS) return "available";
+  if (lastVisibleAt !== null && now - lastVisibleAt < VISITOR_AWAY_DELAY_MS) {
+    return "available";
+  }
+  return "away";
 }

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -2,7 +2,7 @@
 // ABOUTME: Covers reply mention draft behavior used by the chat input.
 
 import { describe, expect, test } from "bun:test";
-import { startReplyDraft } from "../src/utils/chat";
+import { isScrolledNearBottom, startReplyDraft } from "../src/utils/chat";
 
 describe("startReplyDraft", () => {
   test("starts an empty draft with a reply mention", () => {
@@ -19,5 +19,19 @@ describe("startReplyDraft", () => {
 
   test("uses someone when the message has no name", () => {
     expect(startReplyDraft("", undefined)).toBe("@someone ");
+  });
+});
+
+describe("isScrolledNearBottom", () => {
+  test("returns true when the scroll position is at the bottom", () => {
+    expect(isScrolledNearBottom(700, 300, 1000)).toBe(true);
+  });
+
+  test("returns true when the scroll position is within the threshold", () => {
+    expect(isScrolledNearBottom(676, 300, 1000)).toBe(true);
+  });
+
+  test("returns false when the user has scrolled away from the bottom", () => {
+    expect(isScrolledNearBottom(500, 300, 1000)).toBe(false);
   });
 });

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -1,0 +1,23 @@
+// ABOUTME: Unit tests for live chat text helpers.
+// ABOUTME: Covers reply mention draft behavior used by the chat input.
+
+import { describe, expect, test } from "bun:test";
+import { startReplyDraft } from "../src/utils/chat";
+
+describe("startReplyDraft", () => {
+  test("starts an empty draft with a reply mention", () => {
+    expect(startReplyDraft("", "spencer")).toBe("@spencer ");
+  });
+
+  test("prepends a reply mention to an existing draft", () => {
+    expect(startReplyDraft("hello", "spencer")).toBe("@spencer hello");
+  });
+
+  test("does not duplicate the same reply mention", () => {
+    expect(startReplyDraft("@spencer hello", "spencer")).toBe("@spencer hello");
+  });
+
+  test("uses someone when the message has no name", () => {
+    expect(startReplyDraft("", undefined)).toBe("@someone ");
+  });
+});

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -1,26 +1,8 @@
-// ABOUTME: Unit tests for live chat text helpers.
-// ABOUTME: Covers reply mention draft behavior used by the chat input.
+// ABOUTME: Unit tests for live chat behavior helpers.
+// ABOUTME: Covers scroll decisions used by the chat message pane.
 
 import { describe, expect, test } from "bun:test";
-import { isScrolledNearBottom, startReplyDraft } from "../src/utils/chat";
-
-describe("startReplyDraft", () => {
-  test("starts an empty draft with a reply mention", () => {
-    expect(startReplyDraft("", "spencer")).toBe("@spencer ");
-  });
-
-  test("prepends a reply mention to an existing draft", () => {
-    expect(startReplyDraft("hello", "spencer")).toBe("@spencer hello");
-  });
-
-  test("does not duplicate the same reply mention", () => {
-    expect(startReplyDraft("@spencer hello", "spencer")).toBe("@spencer hello");
-  });
-
-  test("uses someone when the message has no name", () => {
-    expect(startReplyDraft("", undefined)).toBe("@someone ");
-  });
-});
+import { isScrolledNearBottom } from "../src/utils/chat";
 
 describe("isScrolledNearBottom", () => {
   test("returns true when the scroll position is at the bottom", () => {

--- a/tests/presence.test.ts
+++ b/tests/presence.test.ts
@@ -1,0 +1,97 @@
+// ABOUTME: Unit tests for shared playhtml presence detection helpers.
+// ABOUTME: Covers Spencer identity and chat availability status decisions.
+
+import { describe, expect, test } from "bun:test";
+import type { CursorPresenceView } from "@playhtml/common";
+import {
+  SPENCER_COLOR,
+  VISITOR_AWAY_DELAY_MS,
+  getSpencerChatStatus,
+  getVisitorAvailability,
+} from "../src/utils/presence";
+
+function presence(name: string, color: string): CursorPresenceView {
+  return {
+    playerIdentity: {
+      name,
+      publicKey: `${name}-key`,
+      playerStyle: {
+        colorPalette: [color],
+      },
+    },
+  } as CursorPresenceView;
+}
+
+describe("getSpencerChatStatus", () => {
+  test("returns absent when Spencer is not present", () => {
+    const presences = new Map<string, CursorPresenceView>([
+      ["visitor-key", presence("visitor", "#888")],
+    ]);
+
+    expect(getSpencerChatStatus(presences, new Map())).toBe("absent");
+  });
+
+  test("returns home when Spencer is present and active", () => {
+    const presences = new Map<string, CursorPresenceView>([
+      ["spencer-key", presence("spencer", SPENCER_COLOR)],
+    ]);
+    const activePresences = new Map<string, { active?: boolean }>([
+      ["spencer-key", { active: true }],
+    ]);
+
+    expect(getSpencerChatStatus(presences, activePresences)).toBe("home");
+  });
+
+  test("returns away when Spencer is present and inactive", () => {
+    const presences = new Map<string, CursorPresenceView>([
+      ["spencer-key", presence("spencer", SPENCER_COLOR)],
+    ]);
+    const activePresences = new Map<string, { active?: boolean }>([
+      ["spencer-key", { active: false }],
+    ]);
+
+    expect(getSpencerChatStatus(presences, activePresences)).toBe("away");
+  });
+
+  test("returns home when Spencer is present without active presence data", () => {
+    const presences = new Map<string, CursorPresenceView>([
+      ["spencer-key", presence("spencer", SPENCER_COLOR)],
+    ]);
+
+    expect(getSpencerChatStatus(presences, new Map())).toBe("home");
+  });
+});
+
+describe("getVisitorAvailability", () => {
+  test("returns available while the page is visible", () => {
+    expect(getVisitorAvailability(false, null, null, 1000)).toBe("available");
+  });
+
+  test("returns available before the away delay has elapsed", () => {
+    expect(
+      getVisitorAvailability(
+        true,
+        1000,
+        null,
+        1000 + VISITOR_AWAY_DELAY_MS - 1,
+      ),
+    ).toBe("available");
+  });
+
+  test("returns away after the away delay has elapsed", () => {
+    expect(
+      getVisitorAvailability(true, 1000, null, 1000 + VISITOR_AWAY_DELAY_MS),
+    ).toBe("away");
+  });
+
+  test("returns available when another tab was visible recently", () => {
+    expect(
+      getVisitorAvailability(
+        true,
+        1000,
+        1000 + VISITOR_AWAY_DELAY_MS,
+        1000 + VISITOR_AWAY_DELAY_MS + 1,
+      ),
+    ).toBe("available");
+  });
+});


### PR DESCRIPTION
## Summary
- Add Spencer away detection for live chat presence when all site tabs have been unfocused for a short period
- Update live chat copy and layout: `spencer home`, `spencer is away`, wider chat window, shorter name placeholder, and message text wrapping under names
- Respect manual chat scroll position and switch cursor coordinates to absolute mode

## Validation
- `bun test tests/chat.test.ts tests/presence.test.ts`
- `bun run check`
- `git diff --check origin/main...HEAD`

Notes: `bun run check` passes with the existing 14 hints in unrelated files.
