### PR TITLE
Fix creation detail image zoom

### DIFF
--- a/src/components/ImageZoom.tsx
+++ b/src/components/ImageZoom.tsx
@@ -1,3 +1,5 @@
+// ABOUTME: Renders an image element with medium-zoom behavior attached.
+// ABOUTME: Preserves normal image props while wiring the zoom ref callback.
 import { ComponentProps, RefCallback } from "react";
 import React from "react";
 import { useZoom } from "../hooks/useZoom";
@@ -9,10 +11,6 @@ type MediaZoomProps = Omit<ComponentProps<"img">, "ref"> & {
 
 export function ImageZoom({ options, src, ...props }: MediaZoomProps) {
   const { attachZoom } = useZoom({ options });
-
-  if (!attachZoom) {
-    console.log("attachZoom", attachZoom);
-  }
 
   return (
     <img

--- a/src/context/ZoomContext.tsx
+++ b/src/context/ZoomContext.tsx
@@ -1,6 +1,8 @@
+// ABOUTME: Provides a shared image zoom session for gallery components.
+// ABOUTME: Handles keyboard navigation between images attached to the session.
 import { type Zoom } from "medium-zoom";
 import mediumZoom, { type ZoomOptions } from "medium-zoom";
-import { createContext, useRef } from "react";
+import { createContext, useEffect, useRef } from "react";
 
 export const ZoomContext = createContext<{
   getZoom: () => Zoom | null;
@@ -24,6 +26,60 @@ export function ZoomContextProvider({
 
     return zoomRef.current;
   }
+
+  function handleKey(e: KeyboardEvent) {
+    const zoom = zoomRef.current;
+    if (!zoom) return;
+
+    const images = zoom.getImages();
+    const currentImageIndex = images.indexOf(zoom.getZoomedImage());
+    const key = e.code || e.key;
+    let target;
+
+    if (images.length <= 1 || currentImageIndex === -1) {
+      return;
+    }
+
+    switch (key) {
+      case "ArrowLeft":
+        e.preventDefault();
+        target =
+          currentImageIndex - 1 < 0
+            ? images[images.length - 1]
+            : images[currentImageIndex - 1];
+        zoom.close().then(() => {
+          target.scrollIntoView();
+          zoom.open({
+            target: target,
+          });
+        });
+        break;
+      case "ArrowRight":
+        e.preventDefault();
+        target =
+          currentImageIndex + 1 >= images.length
+            ? images[0]
+            : images[currentImageIndex + 1];
+        zoom.close().then(() => {
+          target.scrollIntoView();
+          zoom.open({
+            target: target,
+          });
+        });
+        break;
+      default:
+        break;
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKey, false);
+
+    return () => {
+      document.removeEventListener("keydown", handleKey, false);
+      zoomRef.current?.detach();
+    };
+  }, []);
 
   return (
     <ZoomContext.Provider value={{ getZoom }}>{children}</ZoomContext.Provider>

--- a/src/context/ZoomContext.tsx
+++ b/src/context/ZoomContext.tsx
@@ -1,8 +1,9 @@
-// ABOUTME: Provides a shared image zoom session for gallery components.
-// ABOUTME: Handles keyboard navigation between images attached to the session.
+// ABOUTME: Provides access to the page-level image zoom session.
+// ABOUTME: Lets grouped gallery components share the same zoom instance.
 import { type Zoom } from "medium-zoom";
-import mediumZoom, { type ZoomOptions } from "medium-zoom";
-import { createContext, useEffect, useRef } from "react";
+import { type ZoomOptions } from "medium-zoom";
+import { createContext } from "react";
+import { getPageZoom } from "../utils/imageZoom";
 
 export const ZoomContext = createContext<{
   getZoom: () => Zoom | null;
@@ -17,69 +18,9 @@ export function ZoomContextProvider({
   children: React.ReactNode;
   options?: ZoomOptions;
 }) {
-  const zoomRef = useRef<Zoom | null>(null);
-
   function getZoom() {
-    if (zoomRef.current === null) {
-      zoomRef.current = mediumZoom(options);
-    }
-
-    return zoomRef.current;
+    return getPageZoom(options);
   }
-
-  function handleKey(e: KeyboardEvent) {
-    const zoom = zoomRef.current;
-    if (!zoom) return;
-
-    const images = zoom.getImages();
-    const currentImageIndex = images.indexOf(zoom.getZoomedImage());
-    const key = e.code || e.key;
-    let target;
-
-    if (images.length <= 1 || currentImageIndex === -1) {
-      return;
-    }
-
-    switch (key) {
-      case "ArrowLeft":
-        e.preventDefault();
-        target =
-          currentImageIndex - 1 < 0
-            ? images[images.length - 1]
-            : images[currentImageIndex - 1];
-        zoom.close().then(() => {
-          target.scrollIntoView();
-          zoom.open({
-            target: target,
-          });
-        });
-        break;
-      case "ArrowRight":
-        e.preventDefault();
-        target =
-          currentImageIndex + 1 >= images.length
-            ? images[0]
-            : images[currentImageIndex + 1];
-        zoom.close().then(() => {
-          target.scrollIntoView();
-          zoom.open({
-            target: target,
-          });
-        });
-        break;
-      default:
-        break;
-    }
-  }
-
-  useEffect(() => {
-    document.addEventListener("keydown", handleKey, false);
-
-    return () => {
-      document.removeEventListener("keydown", handleKey, false);
-      zoomRef.current?.detach();
-    };
-  }, []);
 
   return (
     <ZoomContext.Provider value={{ getZoom }}>{children}</ZoomContext.Provider>

--- a/src/hooks/useZoom.ts
+++ b/src/hooks/useZoom.ts
@@ -1,27 +1,23 @@
 // ABOUTME: Attaches image elements to the nearest shared zoom session.
-// ABOUTME: Falls back to a local zoom session when no provider is present.
-import mediumZoom, { type ZoomOptions, type Zoom } from "medium-zoom";
+// ABOUTME: Uses the page-level zoom session when no provider is present.
+import { type ZoomOptions } from "medium-zoom";
 import { useCallback, useRef, type RefCallback } from "react";
 import { useContext } from "react";
 import { ZoomContext } from "../context/ZoomContext";
+import { getPageZoom } from "../utils/imageZoom";
 
 // TODO: this is so much weird overhead + needs the context which is super annoying. should be easier to do this without needing the context to understand all the zoom images on the same page.
 // Also it should work with videos..
 // maybe https://www.lightgalleryjs.com/docs/react-image-video-gallery/?
 export function useZoom({ options }: { options?: ZoomOptions }) {
   const { getZoom: getZoomInit } = useContext(ZoomContext);
-  const localZoomRef = useRef<Zoom | null>(null);
   const attachedNodeRef = useRef<HTMLImageElement | null>(null);
 
   const getZoom = useCallback(() => {
     const zoominit = getZoomInit();
     if (zoominit) return zoominit;
 
-    if (localZoomRef.current === null) {
-      localZoomRef.current = mediumZoom(options);
-    }
-
-    return localZoomRef.current;
+    return getPageZoom(options);
   }, [getZoomInit, options]);
 
   const attachZoom: RefCallback<HTMLImageElement> = useCallback(

--- a/src/hooks/useZoom.ts
+++ b/src/hooks/useZoom.ts
@@ -1,3 +1,5 @@
+// ABOUTME: Attaches image elements to the nearest shared zoom session.
+// ABOUTME: Falls back to a local zoom session when no provider is present.
 import mediumZoom, { type ZoomOptions, type Zoom } from "medium-zoom";
 import { useCallback, useRef, type RefCallback } from "react";
 import { useContext } from "react";
@@ -8,77 +10,38 @@ import { ZoomContext } from "../context/ZoomContext";
 // maybe https://www.lightgalleryjs.com/docs/react-image-video-gallery/?
 export function useZoom({ options }: { options?: ZoomOptions }) {
   const { getZoom: getZoomInit } = useContext(ZoomContext);
+  const localZoomRef = useRef<Zoom | null>(null);
+  const attachedNodeRef = useRef<HTMLImageElement | null>(null);
 
   const getZoom = useCallback(() => {
-    const zoom = mediumZoom(options);
-    return zoom;
-    // const zoominit = getZoomInit();
-    // TODO: this is failing intermittently lol just forget it
-    // return zoominit || zoom;
-  }, [getZoomInit]);
+    const zoominit = getZoomInit();
+    if (zoominit) return zoominit;
 
-  const attachZoom: RefCallback<HTMLImageElement | HTMLVideoElement> =
-    useCallback(
-      (node) => {
-        const zoom = getZoom();
-        zoom.on("open", attachKeyEvents);
-        zoom.on("close", detachKeyEvents);
-
-        if (node) {
-          zoom.attach(node);
-        } else {
-          zoom.detach();
-        }
-      },
-      [getZoom]
-    );
-
-  const attachKeyEvents = (e) => {
-    document.addEventListener("keyup", handleKey, false);
-  };
-  const detachKeyEvents = (e) => {
-    document.removeEventListener("keyup", handleKey, false);
-  };
-  const handleKey = (e) => {
-    // console.log("handleKey", e);
-    const zoom = getZoom();
-    const images = zoom.getImages();
-    const currentImageIndex = images.indexOf(zoom.getZoomedImage());
-    let target;
-
-    if (images.length <= 1) {
-      return;
+    if (localZoomRef.current === null) {
+      localZoomRef.current = mediumZoom(options);
     }
 
-    switch (e.code) {
-      case "ArrowLeft":
-        target =
-          currentImageIndex - 1 < 0
-            ? images[images.length - 1]
-            : images[currentImageIndex - 1];
-        zoom.close().then(() => {
-          target.scrollIntoView();
-          zoom.open({
-            target: target,
-          });
-        });
-        break;
-      case "ArrowRight":
-        target =
-          currentImageIndex + 1 >= images.length
-            ? images[0]
-            : images[currentImageIndex + 1];
-        zoom.close().then(() => {
-          target.scrollIntoView();
-          zoom.open({
-            target: target,
-          });
-        });
-        break;
-      default:
-        break;
-    }
-  };
+    return localZoomRef.current;
+  }, [getZoomInit, options]);
+
+  const attachZoom: RefCallback<HTMLImageElement> = useCallback(
+    (node) => {
+      const zoom = getZoom();
+
+      if (attachedNodeRef.current && attachedNodeRef.current !== node) {
+        zoom.detach(attachedNodeRef.current);
+      }
+
+      if (node) {
+        zoom.attach(node);
+        attachedNodeRef.current = node;
+      } else if (attachedNodeRef.current) {
+        zoom.detach(attachedNodeRef.current);
+        attachedNodeRef.current = null;
+      }
+    },
+    [getZoom]
+  );
 
   return {
     getZoom,

--- a/src/utils/imageZoom.ts
+++ b/src/utils/imageZoom.ts
@@ -1,0 +1,77 @@
+// ABOUTME: Provides page-level image zoom behavior across Astro React islands.
+// ABOUTME: Keeps zoom navigation focused on images that have visible layout boxes.
+import mediumZoom, { type Zoom, type ZoomOptions } from "medium-zoom";
+
+type ZoomImageElement = {
+  getBoundingClientRect(): Pick<DOMRect, "width" | "height">;
+};
+
+let pageZoom: Zoom | null = null;
+
+export function getVisibleZoomImages<T extends ZoomImageElement>(
+  images: T[]
+): T[] {
+  return images.filter((image) => {
+    const rect = image.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0;
+  });
+}
+
+export function getPageZoom(options?: ZoomOptions): Zoom {
+  if (pageZoom === null) {
+    pageZoom = mediumZoom(options);
+    document.addEventListener("keydown", handleZoomKey, false);
+  } else if (options) {
+    pageZoom.update(options);
+  }
+
+  return pageZoom;
+}
+
+function handleZoomKey(e: KeyboardEvent) {
+  const zoom = pageZoom;
+  if (!zoom) return;
+
+  const images = getVisibleZoomImages(zoom.getImages());
+  const currentImageIndex = images.indexOf(zoom.getZoomedImage());
+  const key = e.code || e.key;
+  let target: HTMLElement;
+
+  if (images.length <= 1 || currentImageIndex === -1) {
+    return;
+  }
+
+  switch (key) {
+    case "ArrowLeft":
+      e.preventDefault();
+      target =
+        currentImageIndex - 1 < 0
+          ? images[images.length - 1]
+          : images[currentImageIndex - 1];
+      openZoomTarget(zoom, target);
+      break;
+    case "ArrowRight":
+      e.preventDefault();
+      target =
+        currentImageIndex + 1 >= images.length
+          ? images[0]
+          : images[currentImageIndex + 1];
+      openZoomTarget(zoom, target);
+      break;
+    default:
+      break;
+  }
+}
+
+function openZoomTarget(zoom: Zoom, target: HTMLElement) {
+  zoom.close().then(() => {
+    target.scrollIntoView({ block: "center", inline: "center" });
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        zoom.open({
+          target: target,
+        });
+      });
+    });
+  });
+}

--- a/tests/imageZoom.test.ts
+++ b/tests/imageZoom.test.ts
@@ -1,0 +1,21 @@
+// ABOUTME: Verifies image zoom helpers keep navigation on visible media.
+// ABOUTME: Covers detail pages where duplicated hero media is hidden in flow galleries.
+import { expect, test } from "bun:test";
+import { getVisibleZoomImages } from "../src/utils/imageZoom";
+
+function imageWithSize(width: number, height: number) {
+  return {
+    getBoundingClientRect() {
+      return { width, height };
+    },
+  };
+}
+
+test("getVisibleZoomImages excludes images without layout boxes", () => {
+  const hiddenImage = imageWithSize(0, 0);
+  const visibleImage = imageWithSize(320, 240);
+
+  expect(getVisibleZoomImages([hiddenImage, visibleImage])).toEqual([
+    visibleImage,
+  ]);
+});


### PR DESCRIPTION
## Summary
- Share one page-level medium-zoom instance across Astro React islands so creation detail hero and gallery images participate in the same zoom session.
- Filter hidden duplicate images out of zoom keyboard navigation.
- Wait for the next image layout frame before opening ArrowLeft/ArrowRight targets.

## Root cause
Creation detail pages render hero media and flow-gallery media in separate React islands, so React context alone could not share one zoom session across all visible images. Hidden duplicate gallery images were also still attached to zoom navigation, and immediate keyboard re-open after scroll could leave the next image half-open.

## Validation
- `/Users/spencerchang/.bun/bin/bun test tests/imageZoom.test.ts`
- `/Users/spencerchang/.bun/bin/bun run check`
- `/Users/spencerchang/.bun/bin/bun run build`
- Real Chrome verifier against `http://127.0.0.1:4321/creation/computing-shrines`: hero zoom, ArrowRight, flow-gallery zoom, and close all passed.
