### PR TITLE
Move upcoming events into the sidebar

### DIFF
--- a/src/components/header/Header.astro
+++ b/src/components/header/Header.astro
@@ -2,6 +2,7 @@
 import { ConnectedStats } from "../trinkets/ConnectedStats";
 import { StatusHeader } from "./StatusHeader";
 import HeaderActions from "../header/HeaderActions.astro";
+import SidebarSchedule from "./SidebarSchedule.astro";
 import SocialMediaLinks from "../SocialMediaLinks";
 ---
 
@@ -10,6 +11,7 @@ import SocialMediaLinks from "../SocialMediaLinks";
   <div class="sidebarContainer">
     <StatusHeader client:only="react" />
     <HeaderActions />
+    <SidebarSchedule />
     <div
       class="hide-mobile"
       style="display: flex; flex-direction: column; gap: 0.5em;"

--- a/src/components/header/Header.astro
+++ b/src/components/header/Header.astro
@@ -11,7 +11,6 @@ import SocialMediaLinks from "../SocialMediaLinks";
   <div class="sidebarContainer">
     <StatusHeader client:only="react" />
     <HeaderActions />
-    <SidebarSchedule />
     <div
       class="hide-mobile"
       style="display: flex; flex-direction: column; gap: 0.5em;"
@@ -22,6 +21,7 @@ import SocialMediaLinks from "../SocialMediaLinks";
       <!-- TODO: Music, books, activity, arena? each thing in status? -->
       <!-- i love living? -->
     </div>
+    <SidebarSchedule />
     <div
       style="margin-top: auto"
       class="flex flex-col gap-2 hide-mobile w-full"

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -1,9 +1,10 @@
 ---
-// ABOUTME: Compact sidebar block showing current + upcoming events.
-// ABOUTME: Rendered server-side from the creation collection (forthcoming/ongoing only).
+// ABOUTME: Sidebar wrapper that renders upcoming/current events using the shared
+// ABOUTME: EventsView component, sourced from the creation collection.
 import { getCollection } from "astro:content";
 import { hydrateCreations } from "../../utils/creations";
-import { isEventForthcoming, formatCompactDateRange } from "../../utils";
+import { isEventForthcoming } from "../../utils";
+import { EventsView } from "../views/EventsView";
 
 const upcomingEvents = hydrateCreations(await getCollection("creation"))
   .filter((c) => c.data.isEvent)
@@ -14,100 +15,45 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
     (a, b) =>
       new Date(a.data.date || 0).getTime() -
       new Date(b.data.date || 0).getTime()
-  )
-  .slice(0, 4);
+  );
 ---
 
 {
   upcomingEvents.length > 0 && (
-    <div class="sidebarSchedule hide-mobile">
-      <section class="sidebarBlock">
-        <div class="sidebarLabel">upcoming</div>
-        <ul class="upcomingItems">
-          {upcomingEvents.map((event) => (
-            <li>
-              {event.data.date && (
-                <span class="eventDate">
-                  {formatCompactDateRange(
-                    new Date(event.data.date),
-                    event.data.endDate ? new Date(event.data.endDate) : null
-                  )}
-                </span>
-              )}
-              <span class="eventTitle">
-                {event.data.link ? (
-                  <a href={event.data.link}>{event.data.title}</a>
-                ) : (
-                  event.data.title
-                )}
-                {event.data.location && (
-                  <span class="eventLoc"> · {event.data.location}</span>
-                )}
-              </span>
-            </li>
-          ))}
-        </ul>
-        <a href="/events" class="sidebarMore">all events →</a>
-      </section>
+    <div class="sidebarEvents hide-mobile">
+      <EventsView events={upcomingEvents} />
+      <a href="/events" class="sidebarEventsMore">all events →</a>
     </div>
   )
 }
 
 <style lang="scss">
-  .sidebarSchedule {
-    display: flex;
-    flex-direction: column;
-    gap: 1em;
-    font-size: 12px;
-    line-height: 1.35;
-  }
-
-  .sidebarBlock {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4em;
-  }
-
-  .sidebarLabel {
-    text-transform: lowercase;
-    font-style: italic;
+  .sidebarEvents {
     font-size: 13px;
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    border-bottom: 1px solid currentColor;
-    padding-bottom: 0.2em;
-    opacity: 0.85;
+
+    :global(.eventsView) {
+      gap: 1rem;
+    }
+
+    :global(.event-list) {
+      gap: 0.75rem;
+    }
+
+    :global(.events-section h3) {
+      margin-bottom: 0.35rem;
+    }
+
+    // keep long meta lines from overflowing the narrow sidebar
+    :global(.event-year-group .event-meta) {
+      white-space: normal;
+    }
   }
 
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.45em;
-  }
-
-  .upcomingItems li {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .eventDate {
-    font-size: 10px;
-    opacity: 0.6;
-    white-space: nowrap;
-  }
-
-  .eventLoc {
-    opacity: 0.6;
-  }
-
-  .sidebarMore {
-    font-size: 10px;
+  .sidebarEventsMore {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 11px;
     opacity: 0.7;
-    align-self: flex-end;
 
     &:hover {
       opacity: 1;

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -1,0 +1,159 @@
+---
+// ABOUTME: Compact sidebar block showing current "now" status + upcoming events.
+// ABOUTME: Rendered server-side from the now-entries data and the creation collection.
+import { getCollection } from "astro:content";
+import { hydrateCreations } from "../../utils/creations";
+import { isEventForthcoming, formatCompactDateRange } from "../../utils";
+import { nowEntries } from "../../data/now-entries";
+import { formatNowDate } from "../Now";
+
+const currentNow = nowEntries[0];
+const nowItems = currentNow?.items.slice(0, 3) ?? [];
+const hasMoreNow = (currentNow?.items.length ?? 0) > nowItems.length;
+
+const upcomingEvents = hydrateCreations(await getCollection("creation"))
+  .filter((c) => c.data.isEvent)
+  .filter((c) =>
+    isEventForthcoming(c.data.date, c.data.endDate, c.data.forthcoming)
+  )
+  .sort(
+    (a, b) =>
+      new Date(a.data.date || 0).getTime() -
+      new Date(b.data.date || 0).getTime()
+  )
+  .slice(0, 4);
+---
+
+<div class="sidebarSchedule hide-mobile">
+  {
+    currentNow && (
+      <section class="sidebarBlock">
+        <div class="sidebarLabel">
+          now{" "}
+          <span class="descriptionText">{formatNowDate(currentNow.date)}</span>
+        </div>
+        <ul class="nowItems">
+          {nowItems.map((item) => (
+            <li set:html={item} />
+          ))}
+        </ul>
+        {hasMoreNow && (
+          <a href="/now" class="sidebarMore">
+            more →
+          </a>
+        )}
+      </section>
+    )
+  }
+  {
+    upcomingEvents.length > 0 && (
+      <section class="sidebarBlock">
+        <div class="sidebarLabel">upcoming</div>
+        <ul class="upcomingItems">
+          {upcomingEvents.map((event) => (
+            <li>
+              {event.data.date && (
+                <span class="eventDate">
+                  {formatCompactDateRange(
+                    new Date(event.data.date),
+                    event.data.endDate ? new Date(event.data.endDate) : null
+                  )}
+                </span>
+              )}
+              <span class="eventTitle">
+                {event.data.link ? (
+                  <a href={event.data.link}>{event.data.title}</a>
+                ) : (
+                  event.data.title
+                )}
+                {event.data.location && (
+                  <span class="eventLoc"> · {event.data.location}</span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <a href="/events" class="sidebarMore">all events →</a>
+      </section>
+    )
+  }
+</div>
+
+<style lang="scss">
+  .sidebarSchedule {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  .sidebarBlock {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4em;
+  }
+
+  .sidebarLabel {
+    text-transform: lowercase;
+    font-style: italic;
+    font-size: 13px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    border-bottom: 1px solid currentColor;
+    padding-bottom: 0.2em;
+    opacity: 0.85;
+
+    .descriptionText {
+      font-size: 10px;
+      font-style: normal;
+    }
+  }
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45em;
+  }
+
+  .nowItems li {
+    position: relative;
+    padding-left: 0.85em;
+
+    &::before {
+      content: "–";
+      position: absolute;
+      left: 0;
+      opacity: 0.6;
+    }
+  }
+
+  .upcomingItems li {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .eventDate {
+    font-size: 10px;
+    opacity: 0.6;
+    white-space: nowrap;
+  }
+
+  .eventLoc {
+    opacity: 0.6;
+  }
+
+  .sidebarMore {
+    font-size: 10px;
+    opacity: 0.7;
+    align-self: flex-end;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+</style>

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -1,15 +1,9 @@
 ---
-// ABOUTME: Compact sidebar block showing current "now" status + upcoming events.
-// ABOUTME: Rendered server-side from the now-entries data and the creation collection.
+// ABOUTME: Compact sidebar block showing current + upcoming events.
+// ABOUTME: Rendered server-side from the creation collection (forthcoming/ongoing only).
 import { getCollection } from "astro:content";
 import { hydrateCreations } from "../../utils/creations";
 import { isEventForthcoming, formatCompactDateRange } from "../../utils";
-import { nowEntries } from "../../data/now-entries";
-import { formatNowDate } from "../Now";
-
-const currentNow = nowEntries[0];
-const nowItems = currentNow?.items.slice(0, 3) ?? [];
-const hasMoreNow = (currentNow?.items.length ?? 0) > nowItems.length;
 
 const upcomingEvents = hydrateCreations(await getCollection("creation"))
   .filter((c) => c.data.isEvent)
@@ -24,29 +18,9 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
   .slice(0, 4);
 ---
 
-<div class="sidebarSchedule hide-mobile">
-  {
-    currentNow && (
-      <section class="sidebarBlock">
-        <div class="sidebarLabel">
-          now{" "}
-          <span class="descriptionText">{formatNowDate(currentNow.date)}</span>
-        </div>
-        <ul class="nowItems">
-          {nowItems.map((item) => (
-            <li set:html={item} />
-          ))}
-        </ul>
-        {hasMoreNow && (
-          <a href="/now" class="sidebarMore">
-            more →
-          </a>
-        )}
-      </section>
-    )
-  }
-  {
-    upcomingEvents.length > 0 && (
+{
+  upcomingEvents.length > 0 && (
+    <div class="sidebarSchedule hide-mobile">
       <section class="sidebarBlock">
         <div class="sidebarLabel">upcoming</div>
         <ul class="upcomingItems">
@@ -75,9 +49,9 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
         </ul>
         <a href="/events" class="sidebarMore">all events →</a>
       </section>
-    )
-  }
-</div>
+    </div>
+  )
+}
 
 <style lang="scss">
   .sidebarSchedule {
@@ -104,11 +78,6 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
     border-bottom: 1px solid currentColor;
     padding-bottom: 0.2em;
     opacity: 0.85;
-
-    .descriptionText {
-      font-size: 10px;
-      font-style: normal;
-    }
   }
 
   ul {
@@ -118,18 +87,6 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
     display: flex;
     flex-direction: column;
     gap: 0.45em;
-  }
-
-  .nowItems li {
-    position: relative;
-    padding-left: 0.85em;
-
-    &::before {
-      content: "–";
-      position: absolute;
-      left: 0;
-      opacity: 0.6;
-    }
   }
 
   .upcomingItems li {

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -43,6 +43,11 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
       margin-bottom: 0.35rem;
     }
 
+    // drop the per-year header in the compact sidebar list
+    :global(.event-year-group .year-header) {
+      display: none;
+    }
+
     // keep long meta lines from overflowing the narrow sidebar
     :global(.event-year-group .event-meta) {
       white-space: normal;

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -30,9 +30,21 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
 <style lang="scss">
   .sidebarEvents {
     font-size: 13px;
+    // become its own bounded, scrollable region so the header/nav above and the
+    // social + stats block below stay fixed; only the events list scrolls.
+    // min-height keeps a few events visible instead of collapsing on short screens.
+    flex: 1 1 auto;
+    min-height: 8rem;
+    display: flex;
+    flex-direction: column;
 
     :global(.eventsView) {
       gap: 1rem;
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-y: auto;
+      scrollbar-width: thin;
+      padding-right: 4px;
     }
 
     :global(.event-list) {
@@ -55,6 +67,7 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
   }
 
   .sidebarEventsMore {
+    flex: 0 0 auto;
     display: block;
     margin-top: 0.5rem;
     font-size: 11px;

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -21,6 +21,7 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
 {
   upcomingEvents.length > 0 && (
     <div class="sidebarEvents hide-mobile">
+      <div class="sidebarEventsHeading">Now &amp; Upcoming</div>
       <EventsView events={upcomingEvents} />
       <a href="/events" class="sidebarEventsMore">all events →</a>
     </div>
@@ -29,7 +30,6 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
 
 <style lang="scss">
   .sidebarEvents {
-    font-size: 13px;
     // become its own bounded, scrollable region so the header/nav above and the
     // social + stats block below stay fixed; only the events list scrolls.
     // min-height keeps a few events visible instead of collapsing on short screens.
@@ -39,6 +39,7 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
     flex-direction: column;
 
     :global(.eventsView) {
+      font-size: 13px;
       gap: 1rem;
       flex: 1 1 auto;
       min-height: 0;
@@ -51,8 +52,10 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
       gap: 0.75rem;
     }
 
+    // hide EventsView's own italic "upcoming" heading; we render our own that
+    // matches the other sidebar section headings (e.g. Collections)
     :global(.events-section h3) {
-      margin-bottom: 0.35rem;
+      display: none;
     }
 
     // drop the per-year header in the compact sidebar list
@@ -64,6 +67,13 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
     :global(.event-year-group .event-meta) {
       white-space: normal;
     }
+  }
+
+  // plain heading matching the other sidebar section headings (Collections);
+  // inherits the container font instead of the compact 13px event text
+  .sidebarEventsHeading {
+    flex: 0 0 auto;
+    margin-bottom: 0.5em;
   }
 
   .sidebarEventsMore {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,16 +9,8 @@ import Status from "../components/Status.astro";
 import { hydrateCreations } from "../utils/creations";
 
 const creations = hydrateCreations(await getCollection("creation"))
-  .filter(
-    (c) =>
-      (Boolean(c.data.heroImage) && c.data.featured) ||
-      (c.data.isEvent && c.data.forthcoming)
-  )
+  .filter((c) => Boolean(c.data.heroImage) && c.data.featured)
   .sort((a, b) => {
-    // sort forthcoming first and then by date
-    if (a.data.forthcoming !== b.data.forthcoming) {
-      return a.data.forthcoming ? -1 : 1;
-    }
     return new Date(b.data.date || 0).getTime() - new Date(a.data.date || 0).getTime();
   });
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -604,6 +604,12 @@ footer {
     font-size: 90%;
   }
 
+  // events keep the default orange (internal) / green (external) link styling
+  .sidebarEvents a:not(.socialMediaLink):not(.avatarLink) {
+    color: var(--color-link) !important;
+    font-size: inherit;
+  }
+
   h2 {
     margin: 0;
   }


### PR DESCRIPTION
## What

Fills the sidebar's empty middle space with a list of current/upcoming events, placed below the fits/Collections section.

## Details

- New `src/components/header/SidebarSchedule.astro` fetches forthcoming events from the `creation` collection (sorted soonest-first) and renders them through the shared `EventsView` component, so the styling matches the `/events` page (bold `[location]` brackets, compact date range, institution in parens). Rendered as static server HTML — no extra hydration.
- Shows **all** upcoming events (no cap); the sidebar scrolls (`overflow-y: auto`) if the list is taller than the viewport.
- Hides the per-year header in this compact context (keeps the `upcoming` heading).
- Restores the default link styling for event links — orange for internal, green for external — instead of the sidebar's accent-color override.
- Adds an `all events →` link to `/events`.
- Collections (fits) section is kept as-is, with events sitting below it.

## Notes / follow-ups

- There's a typo in the event data: **"Austrailia"** (Melbourne / Radical Computing entry) — left as-is for now.
- The Collections section is still just the lone `fits` link; open question whether to flesh it out or fold `fits` into the main nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JSJrBXBpTfY2LUodvE5Ay

---
_Generated by [Claude Code](https://claude.ai/code/session_013JSJrBXBpTfY2LUodvE5Ay)_