### PR TITLE
Fix playhtml room timing on navigation

### DIFF
--- a/src/components/interactive/PlayhtmlProvider.tsx
+++ b/src/components/interactive/PlayhtmlProvider.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: Mounted in BaseLayout to provide play context to all interactive components.
 
 import { PlayProvider, PlayContext, playhtml } from "@playhtml/react";
-import { useContext, useEffect, type PropsWithChildren } from "react";
+import { useContext, useEffect, useState, type PropsWithChildren } from "react";
 import { CursorPresenceLayer } from "./CursorPresenceLayer";
 import { LiveChat } from "../LiveChat";
 import { isRegular } from "../../utils/roles";
@@ -10,6 +10,7 @@ import {
   VISITOR_AWAY_DELAY_MS,
   getVisitorAvailability,
 } from "../../utils/presence";
+import { isPlayhtmlReadyForConsumers } from "../../utils/playhtmlReady";
 
 const VISIBLE_TAB_HEARTBEAT_KEY = "spencer-place-visible-tab-at";
 const VISIBLE_TAB_HEARTBEAT_INTERVAL_MS = 5_000;
@@ -134,6 +135,40 @@ function PresenceBroadcaster() {
   return null;
 }
 
+function SyncedPlayhtmlContent({ children }: PropsWithChildren) {
+  const { hasSynced } = useContext(PlayContext);
+  const [hasConfirmedSync, setHasConfirmedSync] = useState(false);
+
+  useEffect(() => {
+    if (!hasSynced) {
+      setHasConfirmedSync(false);
+      return;
+    }
+
+    let canceled = false;
+    Promise.resolve().then(() => {
+      if (!canceled) {
+        setHasConfirmedSync(true);
+      }
+    });
+
+    return () => {
+      canceled = true;
+    };
+  }, [hasSynced]);
+
+  if (!isPlayhtmlReadyForConsumers(hasSynced, hasConfirmedSync)) return null;
+
+  return (
+    <>
+      <CursorPresenceLayer />
+      <PresenceBroadcaster />
+      <LiveChat />
+      {children}
+    </>
+  );
+}
+
 // Strip trailing slash from the pathname so /about/ and /about resolve to
 // the same playhtml room. Cloudflare Pages serves Astro's directory output
 // with a trailing slash, but earlier site config did not — so the database
@@ -165,10 +200,7 @@ export function PlayhtmlProvider({ children }: PropsWithChildren) {
         },
       }}
     >
-      <CursorPresenceLayer />
-      <PresenceBroadcaster />
-      <LiveChat />
-      {children}
+      <SyncedPlayhtmlContent>{children}</SyncedPlayhtmlContent>
     </PlayProvider>
   );
 }

--- a/src/utils/playhtmlReady.ts
+++ b/src/utils/playhtmlReady.ts
@@ -1,0 +1,9 @@
+// ABOUTME: Readiness helper for mounting components that consume playhtml APIs.
+// ABOUTME: Prevents consumers from running before provider sync is confirmed.
+
+export function isPlayhtmlReadyForConsumers(
+  hasSynced: boolean,
+  hasConfirmedSync: boolean,
+) {
+  return hasSynced && hasConfirmedSync;
+}

--- a/tests/playhtmlReady.test.ts
+++ b/tests/playhtmlReady.test.ts
@@ -1,0 +1,13 @@
+// ABOUTME: Unit tests for playhtml readiness decisions used by React islands.
+// ABOUTME: Covers the extra confirmation needed before mounting playhtml consumers.
+
+import { describe, expect, test } from "bun:test";
+import { isPlayhtmlReadyForConsumers } from "../src/utils/playhtmlReady";
+
+describe("isPlayhtmlReadyForConsumers", () => {
+  test("waits for a confirmed synced render", () => {
+    expect(isPlayhtmlReadyForConsumers(false, false)).toBe(false);
+    expect(isPlayhtmlReadyForConsumers(true, false)).toBe(false);
+    expect(isPlayhtmlReadyForConsumers(true, true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Delay PlayHTML consumers until provider sync has been confirmed after mount
- Add a small readiness helper and regression test for the mount timing gate

## Root cause

On Astro client navigation, `PlayProvider` can remount while `@playhtml/react` reports `hasSynced` from the singleton state before room APIs are safe for the current provider lifecycle. `LiveChat` calls `usePresenceRoom("chat")`, which can reach `playhtml.createPresenceRoom()` too early and throw:

```text
playhtml.createPresenceRoom is not available before init()
```

That aborts the React island and prevents the `/creation` page from rendering until refresh.

This is also filed upstream for PlayHTML: https://github.com/spencerc99/playhtml/issues/267

## Validation

- `bun test`
- `bun run check`
- `bun run build`
- Headless Chrome navigation loop from `/` to `/creation`, with `createPresenceRoomErrorCount 0` and the creations list rendered
- Pre-push hook: `astro check` passed with existing 6 hints
