### PR TITLE
Mobile sidebar drawer + showcase view groundwork

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "astro",
       "runtimeExecutable": "bun",
       "runtimeArgs": ["dev"],
-      "port": 4321
+      "port": 4321,
+      "autoPort": true
     }
   ]
 }

--- a/src/components/CategoryStamp.tsx
+++ b/src/components/CategoryStamp.tsx
@@ -1,0 +1,61 @@
+// ABOUTME: Category stamp/chip shown over creation previews and in list rows.
+// ABOUTME: Optionally acts as a filter toggle when onCategoryClick is provided.
+
+import React from "react";
+import { stringToColor } from "../utils";
+
+interface Props {
+  parentCategory?: string;
+  onCategoryClick?: (category: string) => void;
+}
+
+export function CategoryStamp({ parentCategory, onCategoryClick }: Props) {
+  // Category stamp color is derived from the category name (not the title) so
+  // every creation in the same category shares the same stamp color. Kept
+  // low-saturation so categories stay distinguishable without shouting.
+  const categoryStampStyle = parentCategory
+    ? ({
+        "--category-stamp-color": stringToColor(parentCategory, {
+          saturation: 45,
+          lightness: 55,
+        }),
+      } as React.CSSProperties)
+    : undefined;
+
+  if (!parentCategory) {
+    return null;
+  }
+
+  if (onCategoryClick) {
+    return (
+      <span
+        className="categoryStamp interactive"
+        style={categoryStampStyle}
+        role="button"
+        tabIndex={0}
+        title={`Filter by ${parentCategory}`}
+        onClick={(e) => {
+          // Stamp may live inside a cover link, so suppress navigation.
+          e.preventDefault();
+          e.stopPropagation();
+          onCategoryClick(parentCategory);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onCategoryClick(parentCategory);
+          }
+        }}
+      >
+        {parentCategory}
+      </span>
+    );
+  }
+
+  return (
+    <span className="categoryStamp" style={categoryStampStyle}>
+      {parentCategory}
+    </span>
+  );
+}

--- a/src/components/ClockEmbed.tsx
+++ b/src/components/ClockEmbed.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { Footnote } from "./Footnote";
 
+export const CLOCK_CAPTION =
+  "an embed of the clock that I made that changes colors with the time such that every minute has a unique color.";
+
 export function ClockEmbed({
   size = 200,
   timezone,
@@ -11,10 +14,7 @@ export function ClockEmbed({
   return (
     <div id="clockEmbed">
       <a href="https://clock.spencer.place" className="button">
-        <Footnote
-          caption="an embed of the clock that I made that changes colors with the time such that every minute has a unique color."
-          asChild={true}
-        >
+        <Footnote caption={CLOCK_CAPTION} asChild={true}>
           <iframe
             src={
               timezone

--- a/src/components/CreationPreviewMedia.tsx
+++ b/src/components/CreationPreviewMedia.tsx
@@ -1,0 +1,184 @@
+// ABOUTME: Progressive image-to-video preview media for a creation.
+// ABOUTME: Shared by grid cards and showcase cards for the hero preview.
+
+import type { CollectionEntry } from "astro:content";
+import classNames from "classnames";
+import React, { useMemo, useState } from "react";
+import { LazyContainer } from "./LazyContainer";
+import { ImageOrVideo } from "./ImageOrVideo";
+import { maybeTransformImgixUrl } from "../utils/images";
+import { getProgressivePreviewImage } from "../utils/creationPreviewMedia";
+
+interface Props {
+  creation: CollectionEntry<"creation">["data"] & {
+    id: string;
+  };
+  imgixWidth?: number;
+}
+
+export function CreationPreviewMedia({ creation, imgixWidth = 300 }: Props) {
+  const { movieUrl, useImageForPreview, media, assetPreviewIdx, mediaMetadata } =
+    creation;
+  const [hasLoadedMedia, setHasLoadedMedia] = useState(false);
+
+  const transformedMovieUrl = useMemo(() => {
+    if (!movieUrl) {
+      return null;
+    }
+    return maybeTransformImgixUrl(movieUrl, {
+      auto: "format,compress",
+      fit: "max",
+      w: String(imgixWidth),
+    });
+  }, [movieUrl, imgixWidth]);
+
+  const transformedHeroAsset = useMemo(() => {
+    const heroAsset = media[assetPreviewIdx];
+    if (!heroAsset) {
+      return null;
+    }
+    return maybeTransformImgixUrl(heroAsset, {
+      auto: "format,compress",
+      fit: "max",
+      w: String(imgixWidth),
+    });
+  }, [media, assetPreviewIdx, imgixWidth]);
+
+  const transformedProgressivePreviewImage = useMemo(() => {
+    const previewImage = getProgressivePreviewImage({
+      media,
+      mediaMetadata,
+      assetPreviewIdx,
+    });
+    if (!previewImage) {
+      return null;
+    }
+    return maybeTransformImgixUrl(previewImage, {
+      auto: "format,compress",
+      fit: "max",
+      w: String(imgixWidth),
+    });
+  }, [media, mediaMetadata, assetPreviewIdx, imgixWidth]);
+
+  const previewMediaType = mediaMetadata?.[assetPreviewIdx];
+  const progressivePreviewImage =
+    transformedProgressivePreviewImage && !hasLoadedMedia ? (
+      <ImageOrVideo
+        src={transformedProgressivePreviewImage}
+        className="registryImage"
+        loading="lazy"
+        style={{
+          gridArea: "1 / 1",
+          objectFit: "cover",
+          pointerEvents: "none",
+        }}
+        controls={false}
+        withZoom={false}
+        type="image"
+      />
+    ) : null;
+  const hasProgressivePreviewImage = Boolean(progressivePreviewImage);
+  const loadingVideoStyle = {
+    gridArea: "1 / 1",
+    opacity: hasProgressivePreviewImage ? 0 : undefined,
+  };
+
+  if (!useImageForPreview && movieUrl) {
+    return (
+      <LazyContainer
+        style={{
+          borderRadius: "inherit",
+        }}
+      >
+        <div
+          style={{
+            display: "grid",
+            borderRadius: "inherit",
+          }}
+        >
+          {progressivePreviewImage}
+          <video
+            autoPlay
+            muted
+            loop
+            playsInline
+            className={classNames({
+              loading: !hasLoadedMedia && !hasProgressivePreviewImage,
+            })}
+            style={loadingVideoStyle}
+            onLoadedData={() => {
+              setHasLoadedMedia(true);
+            }}
+          >
+            {/* NOTE: this type is required for webm videos to work in safari. not all videos are webm but other ones work too with this so 🤷 */}
+            <source src={transformedMovieUrl} type="video/webm" />
+          </video>
+        </div>
+      </LazyContainer>
+    );
+  }
+
+  if (transformedHeroAsset) {
+    return (
+      <LazyContainer
+        style={{
+          borderRadius: "inherit",
+        }}
+      >
+        {previewMediaType === "video" && transformedProgressivePreviewImage ? (
+          <div
+            style={{
+              display: "grid",
+              borderRadius: "inherit",
+            }}
+          >
+            {progressivePreviewImage}
+            <ImageOrVideo
+              data-src={transformedHeroAsset}
+              className={classNames("lazyload registryImage", {
+                loading: !hasLoadedMedia && !hasProgressivePreviewImage,
+              })}
+              loading="lazy"
+              style={loadingVideoStyle}
+              // video props
+              autoPlay
+              muted
+              loop
+              playsInline
+              controls={false}
+              onLoadedData={() => {
+                setHasLoadedMedia(true);
+              }}
+              withZoom={false}
+              type={previewMediaType}
+            />
+          </div>
+        ) : (
+          <ImageOrVideo
+            data-src={transformedHeroAsset}
+            className={classNames("lazyload registryImage", {
+              loading: !hasLoadedMedia,
+            })}
+            loading="lazy"
+            onLoad={() => {
+              setHasLoadedMedia(true);
+            }}
+            // video props
+            autoPlay
+            muted
+            loop
+            playsInline
+            controls={false}
+            onLoadedData={() => {
+              setHasLoadedMedia(true);
+            }}
+            withZoom={false}
+            type={previewMediaType}
+          />
+        )}
+      </LazyContainer>
+    );
+  }
+
+  return null;
+}

--- a/src/components/CreationShowcase.tsx
+++ b/src/components/CreationShowcase.tsx
@@ -1,13 +1,13 @@
 // ABOUTME: Showcase layout for a small number of creations in high detail:
-// ABOUTME: large media, title, subtext, and a postmark date, in a masonry flow.
+// ABOUTME: large media, title, subtext, and date, laid out as trinket-style cards.
 
 import type { CollectionEntry } from "astro:content";
 import React from "react";
-import Masonry, { ResponsiveMasonry } from "react-responsive-masonry";
 import classNames from "classnames";
 import dayjs from "dayjs";
 import { stringToColor } from "../utils";
 import { CreationPreviewMedia } from "./CreationPreviewMedia";
+import { CategoryStamp } from "./CategoryStamp";
 
 interface ShowcaseProps {
   creations: Array<
@@ -17,21 +17,30 @@ interface ShowcaseProps {
   >;
   // Accounts for if it is in display with something else (matches CreationsView)
   columns?: 1 | 2;
+  onCategoryClick?: (category: string) => void;
 }
-
-const TwoColumnsColumnCountBreakPoints = { 350: 1, 1280: 2 };
-const OneColumnColumnCountBreakPoints = { 350: 1, 800: 2 };
 
 interface ShowcaseCardProps {
   creation: CollectionEntry<"creation">["data"] & {
     id: string;
     forthcoming: boolean;
   };
+  onCategoryClick?: (category: string) => void;
 }
 
-function ShowcaseCard({ creation }: ShowcaseCardProps) {
-  const { id, title, subtext, descriptionMd, date, link, forthcoming } =
-    creation;
+function ShowcaseCard({ creation, onCategoryClick }: ShowcaseCardProps) {
+  const {
+    id,
+    title,
+    subtext,
+    descriptionMd,
+    date,
+    endDate,
+    ongoing,
+    link,
+    forthcoming,
+    parentCategory,
+  } = creation;
   const internalLink = `/creation/${id}`;
   const shouldLinkInternal = Boolean(descriptionMd);
   const externalLink = link;
@@ -41,23 +50,28 @@ function ShowcaseCard({ creation }: ShowcaseCardProps) {
       alpha: 0.3,
     }),
   };
-  const postmark = date
-    ? dayjs(date).format("MMM YYYY")
-    : forthcoming
-    ? "soon"
-    : "";
+  const dateDisplay = [
+    date
+      ? dayjs(date).format("MMM YYYY")
+      : forthcoming
+        ? "in progress..."
+        : "",
+    endDate ? `-${dayjs(endDate).format("MMM YYYY")}` : ongoing ? "-now" : "",
+  ].join("");
 
   const content = (
     <>
       <div className={classNames("showcaseMedia", { forthcoming })}>
-        <CreationPreviewMedia creation={creation} imgixWidth={800} />
+        <CategoryStamp
+          parentCategory={parentCategory}
+          onCategoryClick={onCategoryClick}
+        />
+        <CreationPreviewMedia creation={creation} imgixWidth={600} />
       </div>
       <div className="showcaseCaption">
-        <div className="showcaseTitleRow">
-          <span className="showcaseTitle">{title}</span>
-          {postmark && <span className="showcasePostmark">{postmark}</span>}
-        </div>
+        <div className="showcaseTitle">{title}</div>
         {subtext && <p className="showcaseSubtext">{subtext}</p>}
+        {dateDisplay && <div className="showcaseMeta">{dateDisplay}</div>}
       </div>
     </>
   );
@@ -83,24 +97,25 @@ function ShowcaseCard({ creation }: ShowcaseCardProps) {
   );
 }
 
-export function CreationShowcase({ creations, columns = 1 }: ShowcaseProps) {
-  const columnsCountBreakPoints =
-    columns === 2
-      ? TwoColumnsColumnCountBreakPoints
-      : OneColumnColumnCountBreakPoints;
-
+export function CreationShowcase({
+  creations,
+  columns = 1,
+  onCategoryClick,
+}: ShowcaseProps) {
   return (
-    <div className="creationShowcase">
-      <ResponsiveMasonry columnsCountBreakPoints={columnsCountBreakPoints}>
-        <Masonry gutter="2.5em">
-          {creations.map((creation) => (
-            <ShowcaseCard
-              key={creation.id}
-              creation={{ id: creation.id, ...creation.data }}
-            />
-          ))}
-        </Masonry>
-      </ResponsiveMasonry>
+    <div
+      className={classNames(
+        "creationShowcase",
+        columns === 2 ? "sharedWidth" : "fullWidth",
+      )}
+    >
+      {creations.map((creation) => (
+        <ShowcaseCard
+          key={creation.id}
+          creation={{ id: creation.id, ...creation.data }}
+          onCategoryClick={onCategoryClick}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/CreationShowcase.tsx
+++ b/src/components/CreationShowcase.tsx
@@ -1,0 +1,106 @@
+// ABOUTME: Showcase layout for a small number of creations in high detail:
+// ABOUTME: large media, title, subtext, and a postmark date, in a masonry flow.
+
+import type { CollectionEntry } from "astro:content";
+import React from "react";
+import Masonry, { ResponsiveMasonry } from "react-responsive-masonry";
+import classNames from "classnames";
+import dayjs from "dayjs";
+import { stringToColor } from "../utils";
+import { CreationPreviewMedia } from "./CreationPreviewMedia";
+
+interface ShowcaseProps {
+  creations: Array<
+    CollectionEntry<"creation"> & {
+      data: CollectionEntry<"creation">["data"] & { forthcoming: boolean };
+    }
+  >;
+  // Accounts for if it is in display with something else (matches CreationsView)
+  columns?: 1 | 2;
+}
+
+const TwoColumnsColumnCountBreakPoints = { 350: 1, 1280: 2 };
+const OneColumnColumnCountBreakPoints = { 350: 1, 800: 2 };
+
+interface ShowcaseCardProps {
+  creation: CollectionEntry<"creation">["data"] & {
+    id: string;
+    forthcoming: boolean;
+  };
+}
+
+function ShowcaseCard({ creation }: ShowcaseCardProps) {
+  const { id, title, subtext, descriptionMd, date, link, forthcoming } =
+    creation;
+  const internalLink = `/creation/${id}`;
+  const shouldLinkInternal = Boolean(descriptionMd);
+  const externalLink = link;
+  const style = {
+    "--aura-color": stringToColor(title),
+    "--aura-color-transparent": stringToColor(title, {
+      alpha: 0.3,
+    }),
+  };
+  const postmark = date
+    ? dayjs(date).format("MMM YYYY")
+    : forthcoming
+    ? "soon"
+    : "";
+
+  const content = (
+    <>
+      <div className={classNames("showcaseMedia", { forthcoming })}>
+        <CreationPreviewMedia creation={creation} imgixWidth={800} />
+      </div>
+      <div className="showcaseCaption">
+        <div className="showcaseTitleRow">
+          <span className="showcaseTitle">{title}</span>
+          {postmark && <span className="showcasePostmark">{postmark}</span>}
+        </div>
+        {subtext && <p className="showcaseSubtext">{subtext}</p>}
+      </div>
+    </>
+  );
+
+  if (shouldLinkInternal || externalLink) {
+    return (
+      <a
+        className={classNames("showcaseCard", {
+          external: !shouldLinkInternal,
+        })}
+        href={shouldLinkInternal ? internalLink : externalLink}
+        style={style}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <div className="showcaseCard" style={style}>
+      {content}
+    </div>
+  );
+}
+
+export function CreationShowcase({ creations, columns = 1 }: ShowcaseProps) {
+  const columnsCountBreakPoints =
+    columns === 2
+      ? TwoColumnsColumnCountBreakPoints
+      : OneColumnColumnCountBreakPoints;
+
+  return (
+    <div className="creationShowcase">
+      <ResponsiveMasonry columnsCountBreakPoints={columnsCountBreakPoints}>
+        <Masonry gutter="2.5em">
+          {creations.map((creation) => (
+            <ShowcaseCard
+              key={creation.id}
+              creation={{ id: creation.id, ...creation.data }}
+            />
+          ))}
+        </Masonry>
+      </ResponsiveMasonry>
+    </div>
+  );
+}

--- a/src/components/CreationShowcase.tsx
+++ b/src/components/CreationShowcase.tsx
@@ -15,8 +15,6 @@ interface ShowcaseProps {
       data: CollectionEntry<"creation">["data"] & { forthcoming: boolean };
     }
   >;
-  // Accounts for if it is in display with something else (matches CreationsView)
-  columns?: 1 | 2;
   onCategoryClick?: (category: string) => void;
 }
 
@@ -97,25 +95,18 @@ function ShowcaseCard({ creation, onCategoryClick }: ShowcaseCardProps) {
   );
 }
 
-export function CreationShowcase({
-  creations,
-  columns = 1,
-  onCategoryClick,
-}: ShowcaseProps) {
+export function CreationShowcase({ creations, onCategoryClick }: ShowcaseProps) {
   return (
-    <div
-      className={classNames(
-        "creationShowcase",
-        columns === 2 ? "sharedWidth" : "fullWidth",
-      )}
-    >
-      {creations.map((creation) => (
-        <ShowcaseCard
-          key={creation.id}
-          creation={{ id: creation.id, ...creation.data }}
-          onCategoryClick={onCategoryClick}
-        />
-      ))}
+    <div className="creationShowcaseContainer">
+      <div className="creationShowcase">
+        {creations.map((creation) => (
+          <ShowcaseCard
+            key={creation.id}
+            creation={{ id: creation.id, ...creation.data }}
+            onCategoryClick={onCategoryClick}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/CreationSummary.tsx
+++ b/src/components/CreationSummary.tsx
@@ -10,6 +10,7 @@ import dayjs from "dayjs";
 import { stringToColor } from "../utils";
 import { maybeTransformImgixUrl } from "../utils/images";
 import { CreationPreviewMedia } from "./CreationPreviewMedia";
+import { CategoryStamp } from "./CategoryStamp";
 
 interface Props {
   creation: CollectionEntry<"creation">["data"] & {
@@ -53,49 +54,6 @@ export function CreationSummary({
       alpha: 0.3,
     }),
   };
-  // Category stamp color is derived from the category name (not the title) so
-  // every creation in the same category shares the same stamp color. Kept
-  // low-saturation so categories stay distinguishable without shouting.
-  const categoryStampStyle = parentCategory
-    ? ({
-        "--category-stamp-color": stringToColor(parentCategory, {
-          saturation: 45,
-          lightness: 55,
-        }),
-      } as React.CSSProperties)
-    : undefined;
-  // Shared category stamp/chip reused by both grid overlays and the list view's
-  // "kind" column. When onCategoryClick is provided it becomes a filter toggle.
-  const categoryStamp = parentCategory ? (
-    onCategoryClick ? (
-      <span
-        className="categoryStamp interactive"
-        style={categoryStampStyle}
-        role="button"
-        tabIndex={0}
-        title={`Filter by ${parentCategory}`}
-        onClick={(e) => {
-          // Stamp may live inside a cover link, so suppress navigation.
-          e.preventDefault();
-          e.stopPropagation();
-          onCategoryClick(parentCategory);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            e.stopPropagation();
-            onCategoryClick(parentCategory);
-          }
-        }}
-      >
-        {parentCategory}
-      </span>
-    ) : (
-      <span className="categoryStamp" style={categoryStampStyle}>
-        {parentCategory}
-      </span>
-    )
-  ) : null;
   const [hasLoadedMedia, setHasLoadedMedia] = useState(false);
 
   const shouldLinkInternal = Boolean(descriptionMd);
@@ -191,7 +149,12 @@ export function CreationSummary({
                 : ""}
           </div>
           <div className="subtext">{subtext}</div>
-          <div className="kind">{categoryStamp}</div>
+          <div className="kind">
+            <CategoryStamp
+              parentCategory={parentCategory}
+              onCategoryClick={onCategoryClick}
+            />
+          </div>
         </div>
       );
     case ViewType.GRID:
@@ -207,7 +170,10 @@ export function CreationSummary({
               <p>{subtext}</p>
             </div>
           )}
-          {categoryStamp}
+          <CategoryStamp
+            parentCategory={parentCategory}
+            onCategoryClick={onCategoryClick}
+          />
           <CreationPreviewMedia creation={creation} />
         </div>
       );

--- a/src/components/CreationSummary.tsx
+++ b/src/components/CreationSummary.tsx
@@ -9,7 +9,7 @@ import { ImageOrVideo } from "./ImageOrVideo";
 import dayjs from "dayjs";
 import { stringToColor } from "../utils";
 import { maybeTransformImgixUrl } from "../utils/images";
-import { getProgressivePreviewImage } from "../utils/creationPreviewMedia";
+import { CreationPreviewMedia } from "./CreationPreviewMedia";
 
 interface Props {
   creation: CollectionEntry<"creation">["data"] & {
@@ -38,7 +38,6 @@ export function CreationSummary({
     ongoing,
     id,
     movieUrl,
-    useImageForPreview,
     link,
     forthcoming,
     media,
@@ -101,18 +100,6 @@ export function CreationSummary({
 
   const shouldLinkInternal = Boolean(descriptionMd);
 
-  // TODO:remove
-  const transformedMovieUrl = useMemo(() => {
-    if (!movieUrl) {
-      return null;
-    }
-    return maybeTransformImgixUrl(movieUrl, {
-      auto: "format,compress",
-      fit: "max",
-      w: "300",
-    });
-  }, [movieUrl]);
-
   const transformedHeroAsset = useMemo(() => {
     const heroAsset = media[assetPreviewIdx];
     if (!heroAsset) {
@@ -124,45 +111,6 @@ export function CreationSummary({
       w: "300",
     });
   }, [media, assetPreviewIdx]);
-
-  const transformedProgressivePreviewImage = useMemo(() => {
-    const previewImage = getProgressivePreviewImage({
-      media,
-      mediaMetadata,
-      assetPreviewIdx,
-    });
-    if (!previewImage) {
-      return null;
-    }
-    return maybeTransformImgixUrl(previewImage, {
-      auto: "format,compress",
-      fit: "max",
-      w: "300",
-    });
-  }, [media, mediaMetadata, assetPreviewIdx]);
-
-  const previewMediaType = mediaMetadata?.[assetPreviewIdx];
-  const progressivePreviewImage =
-    transformedProgressivePreviewImage && !hasLoadedMedia ? (
-      <ImageOrVideo
-        src={transformedProgressivePreviewImage}
-        className="registryImage"
-        loading="lazy"
-        style={{
-          gridArea: "1 / 1",
-          objectFit: "cover",
-          pointerEvents: "none",
-        }}
-        controls={false}
-        withZoom={false}
-        type="image"
-      />
-    ) : null;
-  const hasProgressivePreviewImage = Boolean(progressivePreviewImage);
-  const loadingVideoStyle = {
-    gridArea: "1 / 1",
-    opacity: hasProgressivePreviewImage ? 0 : undefined,
-  };
 
   switch (view) {
     // case ViewType.FREE:
@@ -183,7 +131,7 @@ export function CreationSummary({
     //       </a>
     //     </div>
     //   );
-    case ViewType.LIST:
+    case ViewType.TABLE:
       return (
         <div
           className={classNames("listViewRow", {
@@ -260,97 +208,7 @@ export function CreationSummary({
             </div>
           )}
           {categoryStamp}
-          {!useImageForPreview && movieUrl ? (
-            <LazyContainer
-              style={{
-                borderRadius: "inherit",
-              }}
-            >
-              <div
-                style={{
-                  display: "grid",
-                  borderRadius: "inherit",
-                }}
-              >
-                {progressivePreviewImage}
-                <video
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
-                  className={classNames({
-                    loading: !hasLoadedMedia && !hasProgressivePreviewImage,
-                  })}
-                  style={loadingVideoStyle}
-                  onLoadedData={() => {
-                    setHasLoadedMedia(true);
-                  }}
-                >
-                  {/* NOTE: this type is required for webm videos to work in safari. not all videos are webm but other ones work too with this so 🤷 */}
-                  <source src={transformedMovieUrl} type="video/webm" />
-                </video>
-              </div>
-            </LazyContainer>
-          ) : transformedHeroAsset ? (
-            <LazyContainer
-              style={{
-                borderRadius: "inherit",
-              }}
-            >
-              {previewMediaType === "video" &&
-              transformedProgressivePreviewImage ? (
-                <div
-                  style={{
-                    display: "grid",
-                    borderRadius: "inherit",
-                  }}
-                >
-                  {progressivePreviewImage}
-                  <ImageOrVideo
-                    data-src={transformedHeroAsset}
-                    className={classNames("lazyload registryImage", {
-                      loading: !hasLoadedMedia && !hasProgressivePreviewImage,
-                    })}
-                    loading="lazy"
-                    style={loadingVideoStyle}
-                    // video props
-                    autoPlay
-                    muted
-                    loop
-                    playsInline
-                    controls={false}
-                    onLoadedData={() => {
-                      setHasLoadedMedia(true);
-                    }}
-                    withZoom={false}
-                    type={previewMediaType}
-                  />
-                </div>
-              ) : (
-                <ImageOrVideo
-                  data-src={transformedHeroAsset}
-                  className={classNames("lazyload registryImage", {
-                    loading: !hasLoadedMedia,
-                  })}
-                  loading="lazy"
-                  onLoad={() => {
-                    setHasLoadedMedia(true);
-                  }}
-                  // video props
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
-                  controls={false}
-                  onLoadedData={() => {
-                    setHasLoadedMedia(true);
-                  }}
-                  withZoom={false}
-                  type={previewMediaType}
-                />
-              )}
-            </LazyContainer>
-          ) : null}
+          <CreationPreviewMedia creation={creation} />
         </div>
       );
       const linkedCover =

--- a/src/components/dev/ShowcaseOptions.scss
+++ b/src/components/dev/ShowcaseOptions.scss
@@ -1,0 +1,187 @@
+@import "../../styles/mixins.scss";
+
+.showcaseOptionSection {
+  margin: 3em 0;
+}
+
+// Compact masonry via CSS columns: no JS balancing, no gaps.
+.showcaseCompact {
+  columns: 1;
+  column-gap: 2em;
+
+  @media (min-width: 700px) {
+    columns: 2;
+  }
+
+  > * {
+    display: block;
+    break-inside: avoid;
+    margin-bottom: 2em;
+  }
+}
+
+.scCard {
+  color: inherit;
+  text-decoration: none !important;
+
+  .scMedia {
+    position: relative;
+    border-radius: 0.25em;
+    overflow: hidden;
+
+    img,
+    video {
+      display: block;
+      width: 100%;
+      height: auto;
+      max-height: 400px;
+      object-fit: cover;
+      background: radial-gradient(
+        circle,
+        var(--aura-color) 0%,
+        var(--aura-color) 20%,
+        var(--aura-color-transparent) 100%
+      );
+      @include image-dropshadow();
+      box-shadow: 0px 0px 0.8em 0.3em $color-link-translucent;
+      transition: opacity 0.15s linear;
+    }
+
+    .categoryStamp {
+      position: absolute;
+      z-index: 11;
+      top: 6px;
+      left: 6px;
+      transform: rotate(-3deg);
+      transform-origin: top left;
+      pointer-events: none;
+    }
+
+    &.forthcoming::after {
+      background: url("/assets/wip-banner.png");
+      background-repeat: repeat-x;
+      background-size: contain;
+      border-top-left-radius: inherit;
+      border-top-right-radius: inherit;
+      width: 100%;
+      height: 16px;
+      content: "";
+      display: block;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
+  }
+
+  &.external .scMedia {
+    img,
+    video {
+      box-shadow: 0px 0px 0.8em 0.3em $color-external-link-translucent;
+    }
+  }
+
+  &:hover .scMedia {
+    img,
+    video {
+      opacity: 0.6;
+    }
+  }
+
+  .scSub {
+    margin: 2px 0 0;
+    color: var(--color-text-muted);
+    font-size: 0.9em;
+    line-height: 1.35;
+  }
+}
+
+// A: grid-native — centered italic title, like .creationSummaryTitle
+.scCard-a {
+  .scCaption {
+    margin-top: 6px;
+    text-align: center;
+    padding: 0 4px;
+  }
+
+  .scTitle {
+    font-style: italic;
+    font-weight: 500;
+    line-height: 1.2;
+  }
+
+  &:hover .scTitle {
+    text-decoration: underline;
+  }
+}
+
+// B: editorial row — title left, year right in mono
+.scCard-b {
+  .scCaption {
+    margin-top: 8px;
+    padding: 0 2px;
+  }
+
+  .scTitleRow {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75em;
+  }
+
+  .scTitle {
+    font-weight: 500;
+    line-height: 1.25;
+  }
+
+  .scYear {
+    @extend .mono;
+    flex-shrink: 0;
+    font-size: 0.75em;
+    color: var(--color-text-muted);
+  }
+
+  &:hover .scTitle {
+    text-decoration: underline;
+  }
+}
+
+// C: trinket card — double border + neutral surface, mono metadata row
+.scCard-c {
+  display: block;
+  background: var(--color-neutral-background);
+  border: 3px double var(--border-color);
+  border-radius: 0.25em;
+  padding: 0.5em;
+
+  .scMedia {
+    img,
+    video {
+      // Inside a bounded card the outer glow fights the border; keep just the dropshadow.
+      box-shadow: none;
+    }
+  }
+
+  .scCaption {
+    margin-top: 8px;
+    padding: 0 2px;
+  }
+
+  .scTitle {
+    font-style: italic;
+    font-weight: 500;
+    line-height: 1.2;
+  }
+
+  .scMeta {
+    @extend .mono;
+    margin-top: 4px;
+    font-size: 0.7em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+
+  &:hover .scTitle {
+    text-decoration: underline;
+  }
+}

--- a/src/components/dev/ShowcaseOptions.tsx
+++ b/src/components/dev/ShowcaseOptions.tsx
@@ -1,0 +1,131 @@
+// ABOUTME: Dev-only comparison page component rendering candidate showcase card
+// ABOUTME: designs (variants A/B/C) side by side for design review.
+
+import type { CollectionEntry } from "astro:content";
+import classNames from "classnames";
+import dayjs from "dayjs";
+import React from "react";
+import { stringToColor } from "../../utils";
+import { CreationPreviewMedia } from "../CreationPreviewMedia";
+import { CategoryStamp } from "../CategoryStamp";
+import "./ShowcaseOptions.scss";
+
+type Variant = "a" | "b" | "c";
+
+const VARIANTS: { key: Variant; label: string }[] = [
+  { key: "a", label: "OPTION A — quiet caption (grid-native)" },
+  { key: "b", label: "OPTION B — title row + year" },
+  { key: "c", label: "OPTION C — trinket card" },
+];
+
+interface Props {
+  creations: (CollectionEntry<"creation"> & {
+    data: CollectionEntry<"creation">["data"] & { forthcoming: boolean };
+  })[];
+}
+
+export function ShowcaseOptions({ creations }: Props) {
+  return (
+    <>
+      {VARIANTS.map(({ key, label }) => (
+        <section className="showcaseOptionSection" key={key}>
+          <h2 className="mono" style={{ fontSize: "16px", textTransform: "uppercase" }}>
+            {label}
+          </h2>
+          <div className="showcaseCompact">
+            {creations.map((c) => (
+              <OptionCard
+                key={c.id}
+                creation={{ id: c.id, ...c.data }}
+                variant={key}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </>
+  );
+}
+
+interface OptionCardProps {
+  creation: CollectionEntry<"creation">["data"] & { id: string };
+  variant: Variant;
+}
+
+function OptionCard({ creation, variant }: OptionCardProps) {
+  const { title, subtext, descriptionMd, date, id, link, forthcoming, parentCategory } =
+    creation;
+  const internalLink = `/creation/${id}`;
+  const shouldLinkInternal = Boolean(descriptionMd);
+  const externalLink = link;
+  const auraStyle = {
+    "--aura-color": stringToColor(title),
+    "--aura-color-transparent": stringToColor(title, { alpha: 0.3 }),
+  } as React.CSSProperties;
+
+  let caption: React.ReactNode;
+  if (variant === "a") {
+    caption = (
+      <div className="scCaption">
+        <div className="scTitle">{title}</div>
+        {subtext && <p className="scSub">{subtext}</p>}
+      </div>
+    );
+  } else if (variant === "b") {
+    caption = (
+      <div className="scCaption">
+        <div className="scTitleRow">
+          <span className="scTitle">{title}</span>
+          {date && <span className="scYear">{dayjs(date).format("YYYY")}</span>}
+        </div>
+        {subtext && <p className="scSub">{subtext}</p>}
+      </div>
+    );
+  } else {
+    caption = (
+      <div className="scCaption">
+        <div className="scTitle">{title}</div>
+        {subtext && <p className="scSub">{subtext}</p>}
+        <div className="scMeta">
+          {[
+            date ? dayjs(date).format("MMM YYYY") : forthcoming ? "soon" : null,
+            parentCategory,
+          ]
+            .filter(Boolean)
+            .join(" · ")}
+        </div>
+      </div>
+    );
+  }
+
+  const media = (
+    <div className={classNames("scMedia", { forthcoming })}>
+      <CategoryStamp parentCategory={parentCategory} />
+      <CreationPreviewMedia creation={creation} imgixWidth={600} />
+    </div>
+  );
+
+  const className = classNames("scCard", `scCard-${variant}`, {
+    external: !shouldLinkInternal,
+  });
+
+  if (shouldLinkInternal || externalLink) {
+    return (
+      <a
+        className={className}
+        href={shouldLinkInternal ? internalLink : externalLink}
+        style={auraStyle}
+      >
+        {media}
+        {caption}
+      </a>
+    );
+  }
+
+  return (
+    <div className={className} style={auraStyle}>
+      {media}
+      {caption}
+    </div>
+  );
+}

--- a/src/components/header/Header.astro
+++ b/src/components/header/Header.astro
@@ -6,7 +6,6 @@ import SidebarSchedule from "./SidebarSchedule.astro";
 import SocialMediaLinks from "../SocialMediaLinks";
 ---
 
-<!-- TODO: improve mobile view for expanding / seeing the stuff that is hidden? -->
 <nav id="sidebar">
   <div class="sidebarContainer">
     <StatusHeader client:only="react" />
@@ -24,7 +23,7 @@ import SocialMediaLinks from "../SocialMediaLinks";
     <SidebarSchedule />
     <div
       style="margin-top: auto"
-      class="flex flex-col gap-2 hide-mobile w-full"
+      class="flex flex-col gap-2 w-full sidebarFooter"
     >
       <SocialMediaLinks />
       <div>

--- a/src/components/header/SidebarSchedule.astro
+++ b/src/components/header/SidebarSchedule.astro
@@ -20,7 +20,7 @@ const upcomingEvents = hydrateCreations(await getCollection("creation"))
 
 {
   upcomingEvents.length > 0 && (
-    <div class="sidebarEvents hide-mobile">
+    <div class="sidebarEvents">
       <div class="sidebarEventsHeading">Now &amp; Upcoming</div>
       <EventsView events={upcomingEvents} />
     </div>

--- a/src/components/header/StatusHeader.tsx
+++ b/src/components/header/StatusHeader.tsx
@@ -1,3 +1,6 @@
+// ABOUTME: Sidebar identity block showing the clock embed, Spencer's name, and live timezone/weather.
+// ABOUTME: On mobile, tapping the name toggles the sidebar's expanded drawer revealing desktop-only content.
+
 import React, { useEffect, useState } from "react";
 import { ClockEmbed } from "../ClockEmbed";
 
@@ -9,6 +12,7 @@ interface StatusData {
 
 export function StatusHeader() {
   const [statusData, setStatusData] = useState<StatusData | null>(null);
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     async function fetchStatus() {
@@ -24,6 +28,34 @@ export function StatusHeader() {
     fetchStatus();
   }, []);
 
+  // The expanded drawer lives on #sidebar (Astro-owned), so sync via class.
+  // Only has a visual effect on mobile — the CSS is scoped to the xsmall breakpoint.
+  useEffect(() => {
+    const sidebar = document.getElementById("sidebar");
+    sidebar?.classList.toggle("expanded", expanded);
+    return () => sidebar?.classList.remove("expanded");
+  }, [expanded]);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!(e.target as Element)?.closest?.("#sidebar")) {
+        setExpanded(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [expanded]);
+
+  const toggleExpanded = () => setExpanded((prev) => !prev);
+
   const timezone = statusData?.timezone || "";
   const timezoneShort = statusData?.timezoneShort || "";
   const weatherEmoji = statusData?.location?.split(" ").slice(-1)[0] || "";
@@ -32,12 +64,25 @@ export function StatusHeader() {
     <>
       <div
         style={{ display: "flex", justifyContent: "center" }}
-        className="hide-mobile"
+        className="sidebarClock"
         data-astro-transition-persist="clock-embed"
       >
         <ClockEmbed size={100} timezone={timezone} />
       </div>
-      <div className="avatar">
+      <div
+        className="avatar"
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        aria-controls="sidebar"
+        onClick={toggleExpanded}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggleExpanded();
+          }
+        }}
+      >
         <span className="avatarLink">spencer chang</span>{" "}
         <span className="avatarDescription">
           {timezoneShort} {weatherEmoji}

--- a/src/components/header/StatusHeader.tsx
+++ b/src/components/header/StatusHeader.tsx
@@ -2,7 +2,7 @@
 // ABOUTME: On mobile, tapping the name toggles the sidebar's expanded drawer revealing desktop-only content.
 
 import React, { useEffect, useState } from "react";
-import { ClockEmbed } from "../ClockEmbed";
+import { ClockEmbed, CLOCK_CAPTION } from "../ClockEmbed";
 
 interface StatusData {
   timezone?: string;
@@ -63,11 +63,17 @@ export function StatusHeader() {
   return (
     <>
       <div
-        style={{ display: "flex", justifyContent: "center" }}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
         className="sidebarClock"
         data-astro-transition-persist="clock-embed"
       >
         <ClockEmbed size={100} timezone={timezone} />
+        <span className="sidebarClockCaption">{CLOCK_CAPTION}</span>
       </div>
       <div
         className="avatar"

--- a/src/components/header/StatusHeader.tsx
+++ b/src/components/header/StatusHeader.tsx
@@ -87,6 +87,9 @@ export function StatusHeader() {
         <span className="avatarDescription">
           {timezoneShort} {weatherEmoji}
         </span>
+        <span className="avatarExpandIcon" aria-hidden="true">
+          ▾
+        </span>
       </div>
     </>
   );

--- a/src/components/views/CreationsView.scss
+++ b/src/components/views/CreationsView.scss
@@ -662,8 +662,12 @@
   columns: 1;
   column-gap: 2em;
 
-  @container creation-showcase (min-width: 720px) {
+  @container creation-showcase (min-width: 640px) {
     columns: 2;
+  }
+
+  @container creation-showcase (min-width: 1080px) {
+    columns: 3;
   }
 
   .showcaseCard {
@@ -699,7 +703,7 @@
       display: block;
       width: 100%;
       height: auto;
-      max-height: 400px;
+      max-height: 260px;
       object-fit: cover;
       background: radial-gradient(
         circle,

--- a/src/components/views/CreationsView.scss
+++ b/src/components/views/CreationsView.scss
@@ -649,22 +649,21 @@
   }
 }
 
-// Showcase view: a few projects, up close, on trinket-style cards
+// Showcase view: a few projects, up close, on trinket-style cards.
+// Column count keys off the showcase's own width (not the viewport) so cards
+// never get squished when the showcase shares the page with other content.
+.creationShowcaseContainer {
+  container-type: inline-size;
+  container-name: creation-showcase;
+}
+
 .creationShowcase {
   margin: 1.5em 0 2em;
   columns: 1;
   column-gap: 2em;
 
-  &.fullWidth {
-    @media (min-width: 800px) {
-      columns: 2;
-    }
-  }
-
-  &.sharedWidth {
-    @media (min-width: 1280px) {
-      columns: 2;
-    }
+  @container creation-showcase (min-width: 720px) {
+    columns: 2;
   }
 
   .showcaseCard {

--- a/src/components/views/CreationsView.scss
+++ b/src/components/views/CreationsView.scss
@@ -649,16 +649,41 @@
   }
 }
 
-// Showcase view: a few projects, up close
+// Showcase view: a few projects, up close, on trinket-style cards
 .creationShowcase {
   margin: 1.5em 0 2em;
+  columns: 1;
+  column-gap: 2em;
+
+  &.fullWidth {
+    @media (min-width: 800px) {
+      columns: 2;
+    }
+  }
+
+  &.sharedWidth {
+    @media (min-width: 1280px) {
+      columns: 2;
+    }
+  }
 
   .showcaseCard {
     display: block;
+    break-inside: avoid;
+    margin-bottom: 2em;
+    background: var(--color-neutral-background);
+    border: 3px double var(--border-color);
+    border-radius: 0.25em;
+    padding: 0.5em;
     color: inherit;
     text-decoration: none !important;
 
     &:hover {
+      .showcaseMedia img,
+      .showcaseMedia video {
+        opacity: 0.6;
+      }
+
       .showcaseTitle {
         text-decoration: underline;
       }
@@ -667,14 +692,8 @@
 
   .showcaseMedia {
     position: relative;
-    border-radius: 6px;
+    border-radius: 0.25em;
     overflow: hidden;
-    background: radial-gradient(
-      circle,
-      var(--aura-color) 0%,
-      var(--aura-color) 20%,
-      var(--aura-color-transparent) 100%
-    );
 
     img,
     video {
@@ -683,6 +702,33 @@
       height: auto;
       max-height: 400px;
       object-fit: cover;
+      background: radial-gradient(
+        circle,
+        var(--aura-color) 0%,
+        var(--aura-color) 20%,
+        var(--aura-color-transparent) 100%
+      );
+      @include image-dropshadow();
+      transition: opacity 0.15s linear;
+    }
+
+    .categoryStamp {
+      position: absolute;
+      z-index: 11;
+      top: 6px;
+      left: 6px;
+      transform: rotate(-3deg);
+      transform-origin: top left;
+      pointer-events: none;
+
+      &.interactive {
+        pointer-events: auto;
+
+        &:hover,
+        &:focus-visible {
+          transform: rotate(-3deg) scale(1.06);
+        }
+      }
     }
 
     &.forthcoming::after {
@@ -702,37 +748,30 @@
   }
 
   .showcaseCaption {
-    margin-top: 0.7em;
-    padding: 0 0.15em;
-  }
-
-  .showcaseTitleRow {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75em;
+    margin-top: 10px;
+    padding: 0 4px 4px;
   }
 
   .showcaseTitle {
-    font-family: $site-font-header;
-    font-size: 1.15em;
+    font-style: italic;
     font-weight: 500;
+    font-size: 1.25em;
     line-height: 1.25;
   }
 
-  .showcasePostmark {
-    @extend .mono;
-    flex-shrink: 0;
-    font-size: 0.7em;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
+  .showcaseSubtext {
+    margin: 4px 0 0;
     color: var(--color-text-muted);
+    font-size: 1em;
+    line-height: 1.45;
   }
 
-  .showcaseSubtext {
-    margin: 0.3em 0 0;
+  .showcaseMeta {
+    @extend .mono;
+    margin-top: 6px;
+    font-size: 0.75em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
     color: var(--color-text-muted);
-    font-size: 0.95em;
-    line-height: 1.4;
   }
 }

--- a/src/components/views/CreationsView.scss
+++ b/src/components/views/CreationsView.scss
@@ -648,3 +648,91 @@
     }
   }
 }
+
+// Showcase view: a few projects, up close
+.creationShowcase {
+  margin: 1.5em 0 2em;
+
+  .showcaseCard {
+    display: block;
+    color: inherit;
+    text-decoration: none !important;
+
+    &:hover {
+      .showcaseTitle {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .showcaseMedia {
+    position: relative;
+    border-radius: 6px;
+    overflow: hidden;
+    background: radial-gradient(
+      circle,
+      var(--aura-color) 0%,
+      var(--aura-color) 20%,
+      var(--aura-color-transparent) 100%
+    );
+
+    img,
+    video {
+      display: block;
+      width: 100%;
+      height: auto;
+      max-height: 400px;
+      object-fit: cover;
+    }
+
+    &.forthcoming::after {
+      background: url("/assets/wip-banner.png");
+      background-repeat: repeat-x;
+      background-size: contain;
+      border-top-left-radius: inherit;
+      border-top-right-radius: inherit;
+      width: 100%;
+      height: 16px;
+      content: "";
+      display: block;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
+  }
+
+  .showcaseCaption {
+    margin-top: 0.7em;
+    padding: 0 0.15em;
+  }
+
+  .showcaseTitleRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75em;
+  }
+
+  .showcaseTitle {
+    font-family: $site-font-header;
+    font-size: 1.15em;
+    font-weight: 500;
+    line-height: 1.25;
+  }
+
+  .showcasePostmark {
+    @extend .mono;
+    flex-shrink: 0;
+    font-size: 0.7em;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+  }
+
+  .showcaseSubtext {
+    margin: 0.3em 0 0;
+    color: var(--color-text-muted);
+    font-size: 0.95em;
+    line-height: 1.4;
+  }
+}

--- a/src/components/views/CreationsView.tsx
+++ b/src/components/views/CreationsView.tsx
@@ -144,7 +144,6 @@ export function CreationsView({
         return (
           <CreationShowcase
             creations={filteredCreations}
-            columns={columns}
             onCategoryClick={handleCategoryChange}
           />
         );

--- a/src/components/views/CreationsView.tsx
+++ b/src/components/views/CreationsView.tsx
@@ -142,7 +142,11 @@ export function CreationsView({
     switch (view) {
       case ViewType.LIST:
         return (
-          <CreationShowcase creations={filteredCreations} columns={columns} />
+          <CreationShowcase
+            creations={filteredCreations}
+            columns={columns}
+            onCategoryClick={handleCategoryChange}
+          />
         );
       case ViewType.TABLE:
         return (

--- a/src/components/views/CreationsView.tsx
+++ b/src/components/views/CreationsView.tsx
@@ -5,6 +5,7 @@ import Masonry, { ResponsiveMasonry } from "react-responsive-masonry";
 import "./CreationsView.scss";
 import { EventCreationsList } from "../EventCreationsList";
 import { CreationListView } from "./CreationListView";
+import { CreationShowcase } from "../CreationShowcase";
 import {
   PINNED_CREATIONS,
   FEATURED_CATEGORY,
@@ -17,6 +18,7 @@ export enum ViewType {
   // FREE = "free",
   GRID = "grid",
   LIST = "list",
+  TABLE = "table",
 }
 
 export enum DescriptionType {
@@ -139,6 +141,10 @@ export function CreationsView({
   function renderCreations() {
     switch (view) {
       case ViewType.LIST:
+        return (
+          <CreationShowcase creations={filteredCreations} columns={columns} />
+        );
+      case ViewType.TABLE:
         return (
           <CreationListView
             creations={filteredCreations}
@@ -264,7 +270,7 @@ export function SimpleCreationsList({ creations }: Props) {
             id: creation.id,
             ...creation.data,
           }}
-          view={ViewType.LIST}
+          view={ViewType.TABLE}
         />
       ))}
     </div>

--- a/src/components/views/CreationsView.tsx
+++ b/src/components/views/CreationsView.tsx
@@ -245,11 +245,14 @@ export function CreationsView({
               setView(e.target.value);
             }}
           >
-            {Object.values(ViewType).map((viewType) => (
-              <option key={viewType} value={viewType}>
-                {viewType}
-              </option>
-            ))}
+            {/* TODO: offer LIST once the showcase design settles */}
+            {Object.values(ViewType)
+              .filter((viewType) => viewType !== ViewType.LIST)
+              .map((viewType) => (
+                <option key={viewType} value={viewType}>
+                  {viewType}
+                </option>
+              ))}
           </select>
         </div>
         {/* TODO: sort */}

--- a/src/pages/creation/index.astro
+++ b/src/pages/creation/index.astro
@@ -2,7 +2,12 @@
 import { getCollection } from "astro:content";
 import { CreationsView } from "../../components/views/CreationsView";
 import DetailLayout from "../../layouts/DetailLayout.astro";
-import { hydrateCreations, PINNED_CREATIONS } from "../../utils/creations";
+import { CreationShowcase } from "../../components/CreationShowcase";
+import {
+  hydrateCreations,
+  isFeaturedCreation,
+  PINNED_CREATIONS,
+} from "../../utils/creations";
 
 const creations = hydrateCreations(await getCollection("creation")).sort(
   (a, b) => {
@@ -23,6 +28,10 @@ const creations = hydrateCreations(await getCollection("creation")).sort(
     );
   },
 );
+
+const showcaseCreations = creations
+  .filter((c) => isFeaturedCreation(c.data))
+  .slice(0, 12);
 
 const LayoutProps = {
   // title: "(creations)",
@@ -51,11 +60,30 @@ const LayoutProps = {
       forward a world that looks like that.
     </p>
   </div>
+  <div class="showcaseSection">
+    <span
+      class="mono"
+      style="font-size: 18px; text-transform: uppercase; font-weight: bold;"
+    >
+      UP CLOSE
+    </span>
+    <CreationShowcase
+      creations={showcaseCreations}
+      columns={1}
+      client:only="react"
+    />
+    <span
+      class="mono"
+      style="font-size: 18px; text-transform: uppercase; font-weight: bold;"
+    >
+      THE FULL CATALOG
+    </span>
+  </div>
   <CreationsView
     creations={creations}
     columns={1}
     client:only="react"
-    defaultView="list"
+    defaultView="table"
     showEvents={false}
   />
 </DetailLayout>

--- a/src/pages/creation/index.astro
+++ b/src/pages/creation/index.astro
@@ -67,11 +67,7 @@ const LayoutProps = {
     >
       UP CLOSE
     </span>
-    <CreationShowcase
-      creations={showcaseCreations}
-      columns={1}
-      client:only="react"
-    />
+    <CreationShowcase creations={showcaseCreations} client:only="react" />
     <span
       class="mono"
       style="font-size: 18px; text-transform: uppercase; font-weight: bold;"

--- a/src/pages/creation/index.astro
+++ b/src/pages/creation/index.astro
@@ -29,6 +29,8 @@ const creations = hydrateCreations(await getCollection("creation")).sort(
   },
 );
 
+// TODO: flip on once the showcase (list) design settles
+const SHOW_UP_CLOSE = false;
 const showcaseCreations = creations
   .filter((c) => isFeaturedCreation(c.data))
   .slice(0, 12);
@@ -60,21 +62,25 @@ const LayoutProps = {
       forward a world that looks like that.
     </p>
   </div>
-  <div class="showcaseSection">
-    <span
-      class="mono"
-      style="font-size: 18px; text-transform: uppercase; font-weight: bold;"
-    >
-      UP CLOSE
-    </span>
-    <CreationShowcase creations={showcaseCreations} client:only="react" />
-    <span
-      class="mono"
-      style="font-size: 18px; text-transform: uppercase; font-weight: bold;"
-    >
-      THE FULL CATALOG
-    </span>
-  </div>
+  {
+    SHOW_UP_CLOSE && (
+      <div class="showcaseSection">
+        <span
+          class="mono"
+          style="font-size: 18px; text-transform: uppercase; font-weight: bold;"
+        >
+          UP CLOSE
+        </span>
+        <CreationShowcase creations={showcaseCreations} client:only="react" />
+        <span
+          class="mono"
+          style="font-size: 18px; text-transform: uppercase; font-weight: bold;"
+        >
+          THE FULL CATALOG
+        </span>
+      </div>
+    )
+  }
   <CreationsView
     creations={creations}
     columns={1}

--- a/src/pages/dev/showcase-options.astro
+++ b/src/pages/dev/showcase-options.astro
@@ -1,0 +1,26 @@
+---
+// ABOUTME: Development page for comparing candidate showcase card designs
+// ABOUTME: Only accessible in development mode
+
+import { getCollection } from "astro:content";
+import { hydrateCreations, isFeaturedCreation } from "../../utils/creations";
+import { ShowcaseOptions } from "../../components/dev/ShowcaseOptions";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+
+// Only allow in development
+if (import.meta.env.PROD) {
+  return Astro.redirect("/");
+}
+
+const creations = hydrateCreations(await getCollection("creation"))
+  .filter((c) => isFeaturedCreation(c.data))
+  .sort(
+    (a, b) => new Date(b.data.date || 0).getTime() - new Date(a.data.date || 0).getTime(),
+  )
+  .slice(0, 8);
+---
+
+<BaseLayout title="Showcase Options - Dev Tool">
+  <h1>showcase options</h1>
+  <ShowcaseOptions creations={creations} client:only="react" />
+</BaseLayout>

--- a/src/pages/feed.astro
+++ b/src/pages/feed.astro
@@ -91,6 +91,6 @@ if (
     creations={sortedCreations}
     client:only="react"
     columns={1}
-    defaultView={"list"}
+    defaultView={"table"}
   />
 </DetailLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,7 +120,6 @@ const currentNowEntry = nowEntries[0];
         defaultCategory={FEATURED_CATEGORY}
         description={"selected"}
         columns={2}
-        defaultView={"list"}
         client:only="react"
       />
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,6 +120,7 @@ const currentNowEntry = nowEntries[0];
         defaultCategory={FEATURED_CATEGORY}
         description={"selected"}
         columns={2}
+        defaultView={"list"}
         client:only="react"
       />
     </div>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -590,10 +590,25 @@ footer {
       cursor: pointer;
       -webkit-tap-highlight-color: transparent;
       transition: transform 0.15s ease;
+      display: flex;
+      align-items: center;
+      gap: 4px;
 
       &:active {
         transform: scale(0.96);
       }
+
+      .avatarExpandIcon {
+        display: inline-block;
+        margin-left: 2px;
+        font-size: 0.75em;
+        opacity: 0.55;
+        transition: rotate 0.3s ease;
+      }
+    }
+
+    &.expanded .avatar .avatarExpandIcon {
+      rotate: 180deg;
     }
 
     // Desktop-only sidebar content stays in the layout but hidden until expanded
@@ -622,8 +637,11 @@ footer {
     }
 
     &.expanded {
-      max-height: 94vh;
-      max-height: 94dvh;
+      max-height: 100vh;
+      max-height: 100dvh;
+      height: 100dvh;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
       overflow-y: auto;
       // The translucent background needs a blur to stay legible over page content
       -webkit-backdrop-filter: blur(12px);
@@ -646,11 +664,6 @@ footer {
       .sidebarFooter {
         transition-delay: 0.24s;
       }
-
-      .navbarActions a span.name {
-        display: inline;
-        animation: sidebar-name-in 0.3s ease 0.1s backwards;
-      }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -661,22 +674,7 @@ footer {
       .sidebarFooter {
         transition: none;
       }
-
-      &.expanded .navbarActions a span.name {
-        animation: none;
-      }
     }
-  }
-}
-
-@keyframes sidebar-name-in {
-  from {
-    opacity: 0;
-    transform: translateX(-4px);
-  }
-  to {
-    opacity: 1;
-    transform: none;
   }
 }
 
@@ -772,6 +770,11 @@ footer {
   word-break: break-all;
   white-space: wrap;
   @extend .meta;
+}
+
+// Drawer toggle indicator; only meaningful on mobile where the sidebar collapses
+.avatarExpandIcon {
+  display: none;
 }
 
 .avatarLink {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -647,6 +647,41 @@ footer {
       -webkit-backdrop-filter: blur(12px);
       backdrop-filter: blur(12px);
 
+      // Grid keeps the name + nav row identical to the collapsed bar while
+      // pinning socials/stats to the bottom and letting events fill the middle.
+      .sidebarContainer {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        grid-template-rows: $navBar-height auto minmax(0, 1fr) auto;
+        align-items: center;
+        height: 100%;
+        row-gap: 0.75em;
+
+        .avatar {
+          grid-row: 1;
+          grid-column: 1;
+        }
+        > .navbarActions {
+          grid-row: 1;
+          grid-column: 2;
+        }
+        .sidebarClock {
+          grid-row: 2;
+          grid-column: 1 / -1;
+        }
+        .sidebarEvents {
+          grid-row: 3;
+          grid-column: 1 / -1;
+          align-self: stretch;
+          max-height: none;
+          min-height: 0;
+        }
+        .sidebarFooter {
+          grid-row: 4;
+          grid-column: 1 / -1;
+        }
+      }
+
       .sidebarClock,
       .sidebarEvents,
       .sidebarFooter {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -660,6 +660,8 @@ footer {
         .avatar {
           grid-row: 1;
           grid-column: 1;
+          // Content-sized so the expand chevron stays hugging the name
+          justify-self: start;
         }
         > .navbarActions {
           grid-row: 1;
@@ -668,6 +670,17 @@ footer {
         .sidebarClock {
           grid-row: 2;
           grid-column: 1 / -1;
+
+          .sidebarClockCaption {
+            display: block;
+            max-width: 36ch;
+            margin-top: 6px;
+            text-align: center;
+            font-size: 0.8em;
+            font-style: italic;
+            color: var(--color-text-muted);
+            line-height: 1.35;
+          }
         }
         .sidebarEvents {
           grid-row: 3;
@@ -809,6 +822,11 @@ footer {
 
 // Drawer toggle indicator; only meaningful on mobile where the sidebar collapses
 .avatarExpandIcon {
+  display: none;
+}
+
+// Static clock caption; only shown in the mobile drawer (desktop keeps the hover footnote)
+.sidebarClockCaption {
   display: none;
 }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -574,12 +574,109 @@ footer {
   @include media(xsmallScreen) {
     // Convert to top navbar on mobile
     width: 100%;
-    height: $navBar-height;
+    height: auto;
+    max-height: $navBar-height;
+    overflow: hidden;
     padding: 0 1em;
     left: 0;
     right: 0;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
+    transition: max-height 0.45s cubic-bezier(0.22, 1, 0.36, 1),
+      -webkit-backdrop-filter 0.45s ease, backdrop-filter 0.45s ease;
+
+    // Tapping the name unfolds the navbar into the full desktop sidebar
+    .avatar {
+      cursor: pointer;
+      -webkit-tap-highlight-color: transparent;
+      transition: transform 0.15s ease;
+
+      &:active {
+        transform: scale(0.96);
+      }
+    }
+
+    // Desktop-only sidebar content stays in the layout but hidden until expanded
+    .sidebarClock,
+    .sidebarEvents,
+    .sidebarFooter {
+      width: 100%;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-10px);
+      transition: opacity 0.3s ease,
+        transform 0.35s cubic-bezier(0.22, 1, 0.36, 1),
+        visibility 0s linear 0.35s;
+    }
+
+    .sidebarClock {
+      order: 2;
+    }
+    .sidebarEvents {
+      order: 3;
+      // Long event lists scroll inside their own bounded region in the drawer
+      max-height: 14em;
+    }
+    .sidebarFooter {
+      order: 4;
+    }
+
+    &.expanded {
+      max-height: 94vh;
+      max-height: 94dvh;
+      overflow-y: auto;
+      // The translucent background needs a blur to stay legible over page content
+      -webkit-backdrop-filter: blur(12px);
+      backdrop-filter: blur(12px);
+
+      .sidebarClock,
+      .sidebarEvents,
+      .sidebarFooter {
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+      }
+
+      .sidebarClock {
+        transition-delay: 0.08s;
+      }
+      .sidebarEvents {
+        transition-delay: 0.16s;
+      }
+      .sidebarFooter {
+        transition-delay: 0.24s;
+      }
+
+      .navbarActions a span.name {
+        display: inline;
+        animation: sidebar-name-in 0.3s ease 0.1s backwards;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+
+      .sidebarClock,
+      .sidebarEvents,
+      .sidebarFooter {
+        transition: none;
+      }
+
+      &.expanded .navbarActions a span.name {
+        animation: none;
+      }
+    }
+  }
+}
+
+@keyframes sidebar-name-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
   }
 }
 
@@ -594,9 +691,16 @@ footer {
   @include media(xsmallScreen) {
     flex-direction: row;
     align-items: center;
-    gap: 0.25em;
-    height: inherit;
-    padding: 0;
+    flex-wrap: wrap;
+    gap: 0.75em 0.25em;
+    height: auto;
+    padding: 0 0 1em;
+
+    > .navbarActions {
+      min-height: $navBar-height;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
   }
 
   a:not(.socialMediaLink):not(.avatarLink) {
@@ -627,13 +731,8 @@ footer {
 
   // Hide some elements on mobile to save space
   @include media(xsmallScreen) {
-    .textContent,
-    > div:last-child {
+    .textContent {
       display: none;
-    }
-
-    > div:first-child {
-      display: none; // Hide clock embed on mobile
     }
   }
 }
@@ -2236,8 +2335,8 @@ video {
   aspect-ratio: 1/1;
   width: fit-content;
   height: auto;
-  // Scale down dramatically in mobile navbar
-  #sidebar & {
+  // Scale down dramatically in mobile navbar; full size in the expanded drawer
+  #sidebar:not(.expanded) & {
     @include media(xsmallScreen) {
       width: 32px;
       height: 32px;


### PR DESCRIPTION
## What changed

### Mobile sidebar drawer (shipping)
- Tapping the name in the mobile navbar unfolds it into a fullscreen drawer with everything that's normally desktop-only: the color clock (now with its caption as a static label underneath), the Now & Upcoming events, and the socials + stats trinket.
- The top row (name + nav pills) stays pixel-identical between collapsed and expanded — no layout shift. A small chevron next to the name signals the toggle and flips when open.
- Expanded layout is a grid: events stretch to fill the middle (scrolling internally if long), socials/stats pinned to the bottom. Escape or tapping the name again closes it.

### Showcase "list" view (built but hidden while workshopping)
- The old "list" view is renamed to `table`; a new showcase view takes the `list` slot: trinket-style cards (double border, neutral surface) with grid-style media + aura, the category stamp as a filter toggle, title/subtext/date meta. Layout is CSS columns sized by **container** width (1→3 cols), media capped at 260px.
- Currently hidden per workshopping: the view dropdown filters out `list`, home defaults to grid, and /creation's "UP CLOSE" section is behind `SHOW_UP_CLOSE = false`. All code stays live and type-checked; there's a `/dev/showcase-options` page comparing candidate card designs (A/B/C).
- Refactors along the way: progressive image→video preview extracted into `CreationPreviewMedia` (shared by grid + showcase), category stamp extracted into `CategoryStamp` (shared by table/grid/showcase).

## Notes for review
- `bun.lock` was already resolved on main for the playhtml peer bump; this branch is rebased on latest main (`389f13b`).
- Known quirk observed while testing: `client:only` islands occasionally fail to remount on view-transition navigation (Astro #8944) — pre-existing, not introduced here.
- Verified at 375px/1300px/1400px in the dev server: drawer states, grid regression, /creation table, and the hidden-list behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)